### PR TITLE
APIMAN-327 - Set CORS plugin's test dependencies scope to ...

### DIFF
--- a/cors-policy/pom.xml
+++ b/cors-policy/pom.xml
@@ -28,13 +28,14 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
-
   <build>
     <resources>
       <resource>


### PR DESCRIPTION
APIMAN-327 - Set CORS plugin's test dependencies scope to <scope>test</scope> to avoid including them in the WAR
