### PR TITLE
Keycloak tests

### DIFF
--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.plugins.keycloak_oauth_policy;
 
+import org.apache.commons.lang.StringUtils;
 import org.keycloak.RSATokenVerifier;
 import org.keycloak.VerificationException;
 import org.keycloak.representations.AccessToken;
@@ -84,9 +85,11 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
     }
 
     private String getRawAuthToken(ServiceRequest request) {
-        String rawToken = request.getHeaders().get(AUTHORIZATION_KEY);
+        String rawToken = StringUtils.strip(request.getHeaders().get(AUTHORIZATION_KEY));
 
-        if (rawToken == null) {
+        if (rawToken != null && StringUtils.startsWith(rawToken, "Bearer ")) { //$NON-NLS-1$
+            rawToken = StringUtils.removeStart(rawToken, "Bearer "); //$NON-NLS-1$
+        } else {
             rawToken = request.getQueryParams().get(ACCESS_TOKEN_QUERY_KEY);
         }
 

--- a/keycloak-oauth-policy/src/main/resources/io/apiman/plugins/keycloak_oauth_policy/messages.properties
+++ b/keycloak-oauth-policy/src/main/resources/io/apiman/plugins/keycloak_oauth_policy/messages.properties
@@ -1,1 +1,1 @@
-KeycloakOauthPolicy.no_token_given=OAuth AUTHORIZATION header or access_token query parameter must be provided.
+KeycloakOauthPolicy.no_token_given=OAuth 'Authorization' header or 'access_token' query parameter must be provided.

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthBeanTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.apiman.plugins.keycloak_oauth_policy;
 
 import io.apiman.plugins.keycloak_oauth_policy.beans.KeycloakOauthConfigBean;


### PR DESCRIPTION
Keycloak tests & small fix to follow standard that Auth header should be in format: Authorization: Bearer <token>.

It worked fine before without the Bearer bit, incidentally.
