### PR TITLE
Simple header policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <!-- Instruct the build to use only UTF-8 encoding for source code -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-    
+
     <version.apiman>1.0.3.Final</version.apiman>
 
     <version.javadoc.plugin>2.10.1</version.javadoc.plugin>
@@ -161,6 +161,7 @@
     <module>cors-policy</module>
     <module>keycloak-oauth-policy</module>
     <module>http-security-policy</module>
+    <module>simple-header-policy</module>
   </modules>
 
   <build>

--- a/simple-header-policy/pom.xml
+++ b/simple-header-policy/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apiman.plugins</groupId>
+    <artifactId>apiman-plugins</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>apiman-plugins-simple-header-policy</artifactId>
+  <packaging>war</packaging>
+  <name>apiman-plugins-simple-header-policy</name>
+
+  <dependencies>
+    <!-- apiman dependencies (must be excluded from the WAR) -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-policies</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webResources>
+            <resource>
+              <directory>src/main/apiman</directory>
+              <targetPath>META-INF/apiman</targetPath>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/simple-header-policy/src/main/apiman/plugin.json
+++ b/simple-header-policy/src/main/apiman/plugin.json
@@ -1,0 +1,6 @@
+{
+  "frameworkVersion" : 1.0,
+  "name" : "HTTP Header Policy Plugin",
+  "description" : "Allows the granular addition and removal of headers.",
+  "version" : "${project.version}"
+}

--- a/simple-header-policy/src/main/apiman/policyDefs/schemas/simple-header-PolicyDef.schema
+++ b/simple-header-policy/src/main/apiman/policyDefs/schemas/simple-header-PolicyDef.schema
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "addHeaders": {
+      "title": "Add Headers",
+      "type": "array",
+      "format": "table",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "title": "Header",
+        "properties": {
+          "headerName": {
+            "title": "Header Name",
+            "type": "string",
+            "pattern": "^[^()<>@,;:\\\\<>\\/\\[\\]?={}\\s\\t]+$"
+          },
+          "headerValue": {
+            "title": "Header Value",
+            "type": "string"
+          },
+          "applyTo": {
+            "type": "string",
+            "title": "Apply To",
+            "enum": [
+              "Request",
+              "Response",
+              "Both"
+            ]
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite Existing",
+            "default": false
+          }
+        }
+      }
+    },
+    "stripHeaders": {
+      "title": "Strip Headers",
+      "description": "Removes header key and value pairs when pattern matches.",
+      "type": "array",
+      "format": "table",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "title": "Strip Headers",
+        "properties": {
+          "stripType": {
+            "title": "Strip Header(s) That Match",
+            "type": "string",
+            "enum": [
+              "Key",
+              "Value"
+            ]
+          },
+          "with": {
+            "title": "With Matcher Type",
+            "type": "string",
+            "enum": [
+              "String",
+              "Regex"
+            ]
+          },
+          "pattern": {
+            "title": "Pattern",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/simple-header-policy/src/main/apiman/policyDefs/simple-header-policyDef.json
+++ b/simple-header-policy/src/main/apiman/policyDefs/simple-header-policyDef.json
@@ -1,0 +1,15 @@
+{
+  "id" : "simple-header-policy",
+  "name" : "Simple Header Policy",
+  "description" : "Allows the granular addition and removal of headers.",
+  "policyImpl" : "plugin:${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}/io.apiman.plugins.simpleheaderpolicy.SimpleHeaderPolicy",
+  "icon" : "header",
+  "formType" : "JsonSchema",
+  "templates" : [
+    {
+      "language" : null,
+      "template" : "@{addHeaders.size()} addition rules and @{stripHeaders.size()} deletion rules are active."
+    }
+  ],
+  "form" : "schemas/simple-header-policyDef.schema"
+}

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicy.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicy.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.simpleheaderpolicy;
+
+import java.util.Map;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.plugins.simpleheaderpolicy.beans.AddHeaderBean;
+import io.apiman.plugins.simpleheaderpolicy.beans.SimpleHeaderPolicyDefBean;
+
+/**
+ * Set, overwrite and/or delete headers on request, response or both, with pattern matching available.
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+public class SimpleHeaderPolicy extends AbstractMappedPolicy<SimpleHeaderPolicyDefBean> {
+
+    @Override
+    protected Class<SimpleHeaderPolicyDefBean> getConfigurationClass() {
+        return SimpleHeaderPolicyDefBean.class;
+    }
+
+    @Override
+    protected void doApply(ServiceRequest request, IPolicyContext context, SimpleHeaderPolicyDefBean config,
+            IPolicyChain<ServiceRequest> chain) {
+        setHeaders(request.getHeaders(), config, AddHeaderBean.ApplyTo.REQUEST);
+        stripHeaders(request.getHeaders(), config);
+        chain.doApply(request);
+    }
+
+    @Override
+    protected void doApply(ServiceResponse response, IPolicyContext context,
+            SimpleHeaderPolicyDefBean config, IPolicyChain<ServiceResponse> chain) {
+        setHeaders(response.getHeaders(), config, AddHeaderBean.ApplyTo.RESPONSE);
+        stripHeaders(response.getHeaders(), config);
+        chain.doApply(response);
+    }
+
+    private void setHeaders(Map<String, String> headers, SimpleHeaderPolicyDefBean config,
+            AddHeaderBean.ApplyTo applyTo) {
+        for (AddHeaderBean header : config.getAddHeaders()) {
+            if ((header.getApplyTo() == applyTo || header.getApplyTo() == AddHeaderBean.ApplyTo.BOTH)) {
+                if (header.getOverwrite() || !headers.containsKey(header.getHeaderName())) {
+                    headers.put(header.getHeaderName(), header.getHeaderValue());
+                }
+            }
+        }
+    }
+
+    private void stripHeaders(Map<String, String> headers, SimpleHeaderPolicyDefBean config) {
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            if (config.getKeyRegex().matcher(header.getKey()).matches()) {
+                headers.remove(header.getKey());
+            }
+
+            if (config.getValueRegex().matcher(header.getValue()).matches()) {
+                headers.remove(header.getKey());
+            }
+        }
+    }
+}

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/AddHeaderBean.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/AddHeaderBean.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.simpleheaderpolicy.beans;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.codehaus.jackson.annotate.JsonAnyGetter;
+import org.codehaus.jackson.annotate.JsonAnySetter;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * Header
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "headerName", "headerValue", "applyTo", "overwrite" })
+@SuppressWarnings("nls")
+public class AddHeaderBean {
+
+    /**
+     * Header Name
+     */
+    @JsonProperty("headerName")
+    private String headerName;
+    /**
+     * Header Value
+     * 
+     */
+    @JsonProperty("headerValue")
+    private String headerValue;
+    /**
+     * Apply To 
+     */
+    @JsonProperty("applyTo")
+    private AddHeaderBean.ApplyTo applyTo;
+    /**
+     * Overwrite Existing
+     */
+    @JsonProperty("overwrite")
+    private Boolean overwrite = false;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    /**
+     * Header Name
+     * <p>
+     * 
+     * 
+     * @return The headerName
+     */
+    @JsonProperty("headerName")
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    /**
+     * Header Name
+     * <p>
+     * 
+     * 
+     * @param headerName The headerName
+     */
+    @JsonProperty("headerName")
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
+
+    /**
+     * Header Value
+     * <p>
+     * 
+     * 
+     * @return The headerValue
+     */
+    @JsonProperty("headerValue")
+    public String getHeaderValue() {
+        return headerValue;
+    }
+
+    /**
+     * Header Value
+     * <p>
+     * 
+     * 
+     * @param headerValue The headerValue
+     */
+    @JsonProperty("headerValue")
+    public void setHeaderValue(String headerValue) {
+        this.headerValue = headerValue;
+    }
+
+    /**
+     * Apply To
+     * <p>
+     * 
+     * 
+     * @return The applyTo
+     */
+    @JsonProperty("applyTo")
+    public AddHeaderBean.ApplyTo getApplyTo() {
+        return applyTo;
+    }
+
+    /**
+     * Apply To
+     * <p>
+     * 
+     * 
+     * @param applyTo The applyTo
+     */
+    @JsonProperty("applyTo")
+    public void setApplyTo(AddHeaderBean.ApplyTo applyTo) {
+        this.applyTo = applyTo;
+    }
+
+    /**
+     * Overwrite Existing
+     * <p>
+     * 
+     * 
+     * @return The overwrite
+     */
+    @JsonProperty("overwrite")
+    public Boolean getOverwrite() {
+        return overwrite;
+    }
+
+    /**
+     * Overwrite Existing
+     * <p>
+     * 
+     * 
+     * @param overwrite The overwrite
+     */
+    @JsonProperty("overwrite")
+    public void setOverwrite(Boolean overwrite) {
+        this.overwrite = overwrite;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(headerName).append(headerValue).append(applyTo).append(overwrite)
+                .append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof AddHeaderBean) == false) {
+            return false;
+        }
+        AddHeaderBean rhs = ((AddHeaderBean) other);
+        return new EqualsBuilder().append(headerName, rhs.headerName).append(headerValue, rhs.headerValue)
+                .append(applyTo, rhs.applyTo).append(overwrite, rhs.overwrite)
+                .append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+    @Generated("org.jsonschema2pojo")
+    public static enum ApplyTo {
+
+        REQUEST("Request"), RESPONSE("Response"), BOTH("Both");
+        private final String value;
+        private static Map<String, AddHeaderBean.ApplyTo> constants = new HashMap<>();
+
+        static {
+            for (AddHeaderBean.ApplyTo c : values()) {
+                constants.put(c.value, c);
+            }
+        }
+
+        private ApplyTo(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static AddHeaderBean.ApplyTo fromValue(String value) {
+            AddHeaderBean.ApplyTo constant = constants.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/SimpleHeaderPolicyDefBean.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/SimpleHeaderPolicyDefBean.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.simpleheaderpolicy.beans;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.annotation.Generated;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.codehaus.jackson.annotate.JsonAnyGetter;
+import org.codehaus.jackson.annotate.JsonAnySetter;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * @author Marc Savy <msavy@redhat.com>
+ */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "addHeaders", "stripHeaders" })
+public class SimpleHeaderPolicyDefBean {
+
+    /**
+     * Add Headers
+     */
+    @JsonProperty("addHeaders")
+    @JsonDeserialize(as = java.util.LinkedHashSet.class)
+    private Set<AddHeaderBean> addHeaders = new LinkedHashSet<>();
+    /**
+     * Strip Headers
+     * <p>
+     * Removes header key and value pairs when pattern matches.
+     */
+    @JsonProperty("stripHeaders")
+    @JsonDeserialize(as = java.util.LinkedHashSet.class)
+    private Set<StripHeaderBean> stripHeaders = new LinkedHashSet<>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+    private Pattern stripKeyRegex;
+    private Pattern stripValueRegex;
+
+    /**
+     * Add Headers
+     * 
+     * @return The addHeaders
+     */
+    @JsonProperty("addHeaders")
+    public Set<AddHeaderBean> getAddHeaders() {
+        return addHeaders;
+    }
+
+    /**
+     * Add Headers
+     * 
+     * @param addHeaders The addHeaders
+     */
+    @JsonProperty("addHeaders")
+    public void setAddHeaders(Set<AddHeaderBean> addHeaders) {
+        this.addHeaders = addHeaders;
+    }
+
+    /**
+     * Strip Headers
+     * <p>
+     * Removes header key and value pairs when pattern matches.
+     * 
+     * @return The stripHeaders
+     */
+    @JsonProperty("stripHeaders")
+    public Set<StripHeaderBean> getStripHeaders() {
+        return stripHeaders;
+    }
+
+    /**
+     * Strip Headers
+     * <p>
+     * Removes header key and value pairs when pattern matches.
+     * 
+     * @param stripHeaders The stripHeaders
+     */
+    @JsonProperty("stripHeaders")
+    public void setStripHeaders(Set<StripHeaderBean> stripHeaders) {
+        this.stripHeaders = stripHeaders;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @SuppressWarnings("nls")
+    private Pattern buildRegex(List<StripHeaderBean> itemList) {
+        StringBuilder sb = new StringBuilder();
+        String divider = "";
+
+        for (StripHeaderBean stripHeader : itemList) {
+            String pattern = StringUtils.strip(stripHeader.getPattern());
+            sb.append(divider);
+            sb.append(pattern);
+            divider = "|";
+        }
+
+        return Pattern.compile(sb.toString(), Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(addHeaders).append(stripHeaders).append(additionalProperties)
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof SimpleHeaderPolicyDefBean) == false) {
+            return false;
+        }
+        SimpleHeaderPolicyDefBean rhs = ((SimpleHeaderPolicyDefBean) other);
+        return new EqualsBuilder().append(addHeaders, rhs.addHeaders).append(stripHeaders, rhs.stripHeaders)
+                .append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+    /**
+     * @return the keyRegex
+     */
+    public Pattern getKeyRegex() {
+        if (stripKeyRegex == null) {
+            List<StripHeaderBean> keys = new ArrayList<>();
+
+            for (StripHeaderBean bean : stripHeaders) {
+                if (bean.getStripType() == StripHeaderBean.StripType.KEY) {
+                    keys.add(bean);
+                }
+            }
+
+            stripKeyRegex = buildRegex(keys);
+        }
+        return stripKeyRegex;
+    }
+
+    /**
+     * @return the keyRegex
+     */
+    public Pattern getValueRegex() {
+        if (stripValueRegex == null) {
+            List<StripHeaderBean> values = new ArrayList<>();
+
+            for (StripHeaderBean bean : stripHeaders) {
+                if (bean.getStripType() == StripHeaderBean.StripType.VALUE) {
+                    values.add(bean);
+                }
+            }
+
+            stripValueRegex = buildRegex(values);
+        }
+        return stripValueRegex;
+    }
+}

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/StripHeaderBean.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/StripHeaderBean.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.simpleheaderpolicy.beans;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.codehaus.jackson.annotate.JsonAnyGetter;
+import org.codehaus.jackson.annotate.JsonAnySetter;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * Strip Headers
+ * 
+ * @author Marc Savy <msavy@redhat.com>
+ */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "stripType", "with", "pattern" })
+@SuppressWarnings("nls")
+public class StripHeaderBean {
+
+    /**
+     * Strip Header(s) That Match
+     */
+    @JsonProperty("stripType")
+    private StripHeaderBean.StripType stripType;
+    /**
+     * With Matcher Type
+     */
+    @JsonProperty("with")
+    private StripHeaderBean.With with;
+    /**
+     * Pattern
+     */
+    @JsonProperty("pattern")
+    private String pattern;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    /**
+     * Strip Header(s) That Match
+     * 
+     * @return The stripType
+     */
+    @JsonProperty("stripType")
+    public StripHeaderBean.StripType getStripType() {
+        return stripType;
+    }
+
+    /**
+     * Strip Header(s) That Match
+     * 
+     * @param stripType The stripType
+     */
+    @JsonProperty("stripType")
+    public void setStripType(StripHeaderBean.StripType stripType) {
+        this.stripType = stripType;
+    }
+
+    /**
+     * With Matcher Type
+     * 
+     * @return The with
+     */
+    @JsonProperty("with")
+    public StripHeaderBean.With getWith() {
+        return with;
+    }
+
+    /**
+     * With Matcher Type
+     * 
+     * @param with The with
+     */
+    @JsonProperty("with")
+    public void setWith(StripHeaderBean.With with) {
+        this.with = with;
+    }
+
+    /**
+     * Pattern
+     * 
+     * @return The pattern
+     */
+    @JsonProperty("pattern")
+    public String getPattern() {
+        return pattern;
+    }
+
+    /**
+     * Pattern
+     * 
+     * @param pattern The pattern
+     */
+    @JsonProperty("pattern")
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(stripType).append(with).append(pattern)
+                .append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof StripHeaderBean) == false) {
+            return false;
+        }
+        StripHeaderBean rhs = ((StripHeaderBean) other);
+        return new EqualsBuilder().append(stripType, rhs.stripType).append(with, rhs.with)
+                .append(pattern, rhs.pattern).append(additionalProperties, rhs.additionalProperties)
+                .isEquals();
+    }
+
+    @Generated("org.jsonschema2pojo")
+    public static enum StripType {
+
+        KEY("Key"), VALUE("Value");
+        private final String value;
+        private static Map<String, StripHeaderBean.StripType> constants = new HashMap<>();
+
+        static {
+            for (StripHeaderBean.StripType c : values()) {
+                constants.put(c.value, c);
+            }
+        }
+
+        private StripType(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static StripHeaderBean.StripType fromValue(String value) {
+            StripHeaderBean.StripType constant = constants.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+    @Generated("org.jsonschema2pojo")
+    public static enum With {
+
+        STRING("String"), REGEX("Regex");
+        private final String value;
+        private static Map<String, StripHeaderBean.With> constants = new HashMap<>();
+
+        static {
+            for (StripHeaderBean.With c : values()) {
+                constants.put(c.value, c);
+            }
+        }
+
+        private With(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static StripHeaderBean.With fromValue(String value) {
+            StripHeaderBean.With constant = constants.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/simple-header-policy/src/test/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicyTest.java
+++ b/simple-header-policy/src/test/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicyTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.simpleheaderpolicy;
+
+import static org.junit.Assert.*;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.plugins.simpleheaderpolicy.beans.AddHeaderBean;
+import io.apiman.plugins.simpleheaderpolicy.beans.StripHeaderBean;
+import io.apiman.plugins.simpleheaderpolicy.beans.AddHeaderBean.ApplyTo;
+import io.apiman.plugins.simpleheaderpolicy.beans.StripHeaderBean.StripType;
+import io.apiman.plugins.simpleheaderpolicy.beans.SimpleHeaderPolicyDefBean;
+import io.apiman.plugins.simpleheaderpolicy.beans.StripHeaderBean.With;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Marc Savy <msavy@redhat.com>
+ */
+@SuppressWarnings("nls")
+public class SimpleHeaderPolicyTest {
+    @Mock
+    private IPolicyChain<ServiceRequest> mRequestChain;
+    @Mock
+    private IPolicyChain<ServiceResponse> mResponseChain;
+
+    @Mock
+    private IPolicyContext mContext;
+    private SimpleHeaderPolicy policy;
+    private SimpleHeaderPolicyDefBean config;
+    private ServiceRequest request;
+    private ServiceResponse response;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        policy = new SimpleHeaderPolicy();
+        config = new SimpleHeaderPolicyDefBean();
+        request = new ServiceRequest();
+        response = new ServiceResponse();
+    }
+
+    @Test
+    public void shouldSetHeaderOnRequest() {
+        AddHeaderBean header = new AddHeaderBean();
+        header.setHeaderName("X-Clacks-Overhead");
+        header.setHeaderValue("GNU Terry Pratchett");
+        header.setOverwrite(false);
+        header.setApplyTo(ApplyTo.REQUEST);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("GNU Terry Pratchett", request.getHeaders().get("X-Clacks-Overhead"));
+        assertEquals(1, request.getHeaders().size());
+    }
+
+    @Test
+    public void shouldSetHeaderOnResponse() {
+        AddHeaderBean header = new AddHeaderBean();
+        header.setHeaderName("X-Clacks-Overhead");
+        header.setHeaderValue("GNU Terry Pratchett");
+        header.setOverwrite(false);
+        header.setApplyTo(ApplyTo.RESPONSE);
+        config.getAddHeaders().add(header);
+
+        policy.apply(response, mContext, config, mResponseChain);
+
+        assertEquals("GNU Terry Pratchett", response.getHeaders().get("X-Clacks-Overhead"));
+        assertEquals(1, response.getHeaders().size());
+    }
+
+    @Test
+    public void shouldSetHeaderOnBoth() {
+        AddHeaderBean header = new AddHeaderBean();
+        header.setHeaderName("Request-And-Response");
+        header.setHeaderValue("Weatherwax");
+        header.setOverwrite(false);
+        header.setApplyTo(ApplyTo.BOTH);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("Weatherwax", request.getHeaders().get("Request-And-Response"));
+        assertEquals(1, request.getHeaders().size());
+
+        policy.apply(response, mContext, config, mResponseChain);
+
+        assertEquals("Weatherwax", response.getHeaders().get("Request-And-Response"));
+        assertEquals(1, response.getHeaders().size());
+    }
+
+    @Test
+    public void shouldOverwriteWhenFlagSet() {
+        request.getHeaders().put("X-Clacks-Overhead", "Ridcully");
+
+        AddHeaderBean header = new AddHeaderBean();
+        header.setHeaderName("X-Clacks-Overhead");
+        header.setHeaderValue("GNU Terry Pratchett");
+        header.setOverwrite(true);
+        header.setApplyTo(ApplyTo.REQUEST);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("GNU Terry Pratchett", request.getHeaders().get("X-Clacks-Overhead"));
+        assertEquals(1, request.getHeaders().size());
+    }
+
+    @Test
+    public void shouldNotOverwriteWhenFlagUnset() {
+        request.getHeaders().put("X-Clacks-Overhead", "Ridcully");
+
+        AddHeaderBean header = new AddHeaderBean();
+        header.setHeaderName("X-Clacks-Overhead");
+        header.setHeaderValue("GNU Terry Pratchett");
+        header.setOverwrite(false);
+        header.setApplyTo(ApplyTo.REQUEST);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("Ridcully", request.getHeaders().get("X-Clacks-Overhead"));
+        assertEquals(1, request.getHeaders().size());
+    }
+
+    @Test
+    public void shouldStripHeaderWithKey() {
+        request.getHeaders().put("vanish", "begone");
+
+        StripHeaderBean shb = new StripHeaderBean();
+        shb.setPattern("vanish");
+        shb.setStripType(StripType.KEY);
+        shb.setWith(With.STRING);
+
+        config.getStripHeaders().add(shb);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertFalse(request.getHeaders().containsKey("vanish"));
+    }
+
+    @Test
+    public void shouldStripHeaderWithValue() {
+        request.getHeaders().put("lu", "tze");
+        request.getHeaders().put("lu", "tze");
+
+        StripHeaderBean shb = new StripHeaderBean();
+        shb.setPattern("tze");
+        shb.setStripType(StripType.VALUE);
+        shb.setWith(With.STRING);
+
+        config.getStripHeaders().add(shb);
+
+        policy.apply(request, mContext, config, mRequestChain);
+        policy.apply(response, mContext, config, mResponseChain);
+
+        assertFalse(request.getHeaders().containsKey("lu"));
+        assertFalse(response.getHeaders().containsKey("lu"));
+    }
+
+    @Test
+    public void shouldStripHeaderWithRegexKey() {
+        request.getHeaders().put("sybil", "ramkin");
+
+        StripHeaderBean shb = new StripHeaderBean();
+        shb.setPattern("sy.*l");
+        shb.setStripType(StripType.KEY);
+        shb.setWith(With.REGEX);
+
+        config.getStripHeaders().add(shb);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertFalse(request.getHeaders().containsKey("sybil"));
+        assertTrue(request.getHeaders().isEmpty());
+    }
+
+    @Test
+    public void shouldStripHeaderWithRegexValue() {
+        request.getHeaders().put("lord", "Vetinari");
+
+        StripHeaderBean shb = new StripHeaderBean();
+        shb.setPattern("vetinar\\w+");
+        shb.setStripType(StripType.VALUE);
+        shb.setWith(With.REGEX);
+
+        config.getStripHeaders().add(shb);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertFalse(request.getHeaders().containsKey("vetinari"));
+        assertTrue(request.getHeaders().isEmpty());
+    }
+
+    @Test
+    public void shouldStripCaseInsensitively() {
+        request.getHeaders().put("lord", "Vetinari");
+
+        StripHeaderBean shb = new StripHeaderBean();
+        shb.setPattern("VETINAR\\w+");
+        shb.setStripType(StripType.VALUE);
+        shb.setWith(With.REGEX);
+
+        config.getStripHeaders().add(shb);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertFalse(request.getHeaders().containsKey("vetinari"));
+        assertTrue(request.getHeaders().isEmpty());
+    }
+
+    // @Test
+    // public void shouldTrimWhitespace() {
+    // request.getHeaders().put("      lord      ", " Vetinari ");
+    //
+    // StripHeaderBean shb = new StripHeaderBean();
+    // shb.setPattern("VETINAR\\w+");
+    // shb.setStripType(StripType.KEY);
+    // shb.setWith(With.REGEX);
+    //
+    // config.getStripHeaders().add(shb);
+    //
+    // policy.apply(request, mContext, config, mRequestChain);
+    //
+    // assertFalse(request.getHeaders().containsKey("lord"));
+    // assertTrue(request.getHeaders().isEmpty());
+    // }
+}


### PR DESCRIPTION
Here's a demo of it working:

UI Config: 
![image](https://cloud.githubusercontent.com/assets/423513/6708091/24ee086c-cd65-11e4-92eb-73babad2f60d.png)

UI Summary:
![image](https://cloud.githubusercontent.com/assets/423513/6708103/3d77d124-cd65-11e4-87fd-4eaf168b9fe3.png)

```
[msavy@mmbp tmp]$ curl -v -H "SECRET_KEY: THIS_WILL_DISAPPEAR" -H "PUBLIC_INFO: THIS_WONT_DISAPPEAR" http://127.0.0.1:8080/apiman-gateway/123/echo/1.0
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> GET /apiman-gateway/123/echo/1.0 HTTP/1.1
> User-Agent: curl/7.37.1
> Host: 127.0.0.1:8080
> Accept: */*
> SECRET_KEY: THIS_WILL_DISAPPEAR
> PUBLIC_INFO: THIS_WONT_DISAPPEAR
>
< HTTP/1.1 200 OK
< DEF: RESPONSE_ONLY
< X-Powered-By: Undertow/1
* Server WildFly/8 is not blacklisted
< Server: WildFly/8
< Response-Counter: 8
< Date: Wed, 18 Mar 2015 11:47:45 GMT
< Connection: keep-alive
< Content-Length: 452
< Content-Type: application/json
< XYZ: REQUEST_AND_RESPONSE
<
{
  "method" : "GET",
  "resource" : "/services/echo",
  "uri" : "/services/echo",
  "headers" : {
    "XYZ" : "REQUEST_AND_RESPONSE",
    "ABC" : "REQUEST_ONLY",
    "Host" : "127.0.0.1:8080",
    "User-Agent" : "curl/7.37.1",
    "PUBLIC_INFO" : "THIS_WONT_DISAPPEAR",
    "Accept" : "*/*",
    "Connection" : "keep-alive",
    "Cache-Control" : "no-cache",
    "Pragma" : "no-cache"
  },
  "bodyLength" : null,
  "bodySha1" : null,
  "counter" : 8
* Connection #0 to host 127.0.0.1 left intact
}
```
