### PR TITLE
Add ability to set header value using the environment or system.properties. Provided header value is used as a key.

### DIFF
--- a/simple-header-policy/src/main/apiman/policyDefs/schemas/simple-header-PolicyDef.schema
+++ b/simple-header-policy/src/main/apiman/policyDefs/schemas/simple-header-PolicyDef.schema
@@ -10,6 +10,7 @@
       "items": {
         "type": "object",
         "title": "Header",
+        "description": "Set headers on request, response or both. A value type of 'String' sets the value literally; 'Env' treats the value as a key to the environment; 'System Properties' treats the value as a key to the JVM's System Properties.",
         "properties": {
           "headerName": {
             "title": "Header Name",
@@ -19,6 +20,15 @@
           "headerValue": {
             "title": "Header Value",
             "type": "string"
+          },
+          "valueType": {
+            "type": "string",
+            "title": "Value Type",
+            "enum": [
+              "String",
+              "Env",
+              "System Properties"
+            ]
           },
           "applyTo": {
             "type": "string",

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicy.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicy.java
@@ -23,6 +23,7 @@ import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
 import io.apiman.plugins.simpleheaderpolicy.beans.AddHeaderBean;
+import io.apiman.plugins.simpleheaderpolicy.beans.AddHeaderBean.ApplyTo;
 import io.apiman.plugins.simpleheaderpolicy.beans.SimpleHeaderPolicyDefBean;
 
 /**
@@ -40,7 +41,7 @@ public class SimpleHeaderPolicy extends AbstractMappedPolicy<SimpleHeaderPolicyD
     @Override
     protected void doApply(ServiceRequest request, IPolicyContext context, SimpleHeaderPolicyDefBean config,
             IPolicyChain<ServiceRequest> chain) {
-        setHeaders(request.getHeaders(), config, AddHeaderBean.ApplyTo.REQUEST);
+        setHeaders(request.getHeaders(), config, ApplyTo.REQUEST);
         stripHeaders(request.getHeaders(), config);
         chain.doApply(request);
     }
@@ -48,17 +49,16 @@ public class SimpleHeaderPolicy extends AbstractMappedPolicy<SimpleHeaderPolicyD
     @Override
     protected void doApply(ServiceResponse response, IPolicyContext context,
             SimpleHeaderPolicyDefBean config, IPolicyChain<ServiceResponse> chain) {
-        setHeaders(response.getHeaders(), config, AddHeaderBean.ApplyTo.RESPONSE);
+        setHeaders(response.getHeaders(), config, ApplyTo.RESPONSE);
         stripHeaders(response.getHeaders(), config);
         chain.doApply(response);
     }
 
-    private void setHeaders(Map<String, String> headers, SimpleHeaderPolicyDefBean config,
-            AddHeaderBean.ApplyTo applyTo) {
+    private void setHeaders(Map<String, String> headers, SimpleHeaderPolicyDefBean config, ApplyTo applyTo) {
         for (AddHeaderBean header : config.getAddHeaders()) {
-            if ((header.getApplyTo() == applyTo || header.getApplyTo() == AddHeaderBean.ApplyTo.BOTH)) {
+            if ((header.getApplyTo() == applyTo || header.getApplyTo() == ApplyTo.BOTH)) {
                 if (header.getOverwrite() || !headers.containsKey(header.getHeaderName())) {
-                    headers.put(header.getHeaderName(), header.getHeaderValue());
+                    headers.put(header.getHeaderName(), header.getResolvedHeaderValue());
                 }
             }
         }

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/AddHeaderBean.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/AddHeaderBean.java
@@ -17,7 +17,9 @@ package io.apiman.plugins.simpleheaderpolicy.beans;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.annotation.Generated;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -37,7 +39,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({ "headerName", "headerValue", "applyTo", "overwrite" })
+@JsonPropertyOrder({ "headerName", "headerValue", "valueType", "applyTo", "overwrite" })
 @SuppressWarnings("nls")
 public class AddHeaderBean {
 
@@ -46,14 +48,21 @@ public class AddHeaderBean {
      */
     @JsonProperty("headerName")
     private String headerName;
+
     /**
      * Header Value
-     * 
      */
     @JsonProperty("headerValue")
     private String headerValue;
+
     /**
-     * Apply To 
+     * Value Type
+     */
+    @JsonProperty("valueType")
+    private AddHeaderBean.ValueType valueType;
+
+    /**
+     * Apply To
      */
     @JsonProperty("applyTo")
     private AddHeaderBean.ApplyTo applyTo;
@@ -111,6 +120,30 @@ public class AddHeaderBean {
     @JsonProperty("headerValue")
     public void setHeaderValue(String headerValue) {
         this.headerValue = headerValue;
+    }
+
+    /**
+     * Value Type
+     * <p>
+     * 
+     * 
+     * @return The valueType
+     */
+    @JsonProperty("valueType")
+    public AddHeaderBean.ValueType getValueType() {
+        return valueType;
+    }
+
+    /**
+     * Value Type
+     * <p>
+     * 
+     * 
+     * @param valueType The valueType
+     */
+    @JsonProperty("valueType")
+    public void setValueType(AddHeaderBean.ValueType valueType) {
+        this.valueType = valueType;
     }
 
     /**
@@ -231,4 +264,54 @@ public class AddHeaderBean {
 
     }
 
+    public static enum ValueType {
+
+        STRING("String"), ENV("Env"), SYS("System Properties");
+        private final String value;
+        private static Map<String, AddHeaderBean.ValueType> constants = new HashMap<>();
+
+        static {
+            for (AddHeaderBean.ValueType c : values()) {
+                constants.put(c.value, c);
+            }
+        }
+
+        private ValueType(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static AddHeaderBean.ValueType fromValue(String value) {
+            AddHeaderBean.ValueType constant = constants.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+    public String getResolvedHeaderValue() {
+        String rVal = null;
+
+        switch (getValueType()) {
+        case ENV:
+            rVal = System.getenv(headerValue);
+            break;
+        case SYS:
+            rVal = System.getProperty(headerValue);
+            break;
+        case STRING:
+            rVal = headerValue;
+        }
+
+        return (rVal == null) ? "" : rVal;
+    }
 }


### PR DESCRIPTION
A couple of small additions I've been working on in spare time.

You can now include values from the environment and system.properties.
