### PR TITLE
Keycloak OAuth 2 with security enhancements

### DIFF
--- a/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
+++ b/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
@@ -9,14 +9,20 @@
       "type": "boolean",
       "default": true
     },
-    "blacklistUnsafeTokens": {
-      "title": "Blacklist unsafe tokens",
-      "description": "Any tokens used without transport security will be blackedlisted to mitigate associated security risks.",
+    "requireTransportSecurity": {
+      "title": "Require Transport Security",
+      "description": "Any request used without transport security will be rejected. OAuth2 requires transport security (e.g. TLS, SSL) to provide protection against replay attacks. It is strongly advised for this option to be switched on.",
       "type": "boolean",
       "default": true
     },
+    "blacklistUnsafeTokens": {
+      "title": "Blacklist Unsafe Tokens",
+      "description": "Any tokens used without transport security will be blackedlisted in all gateways to mitigate associated security risks. Uses distributed data store to share blacklist.",
+      "type": "boolean",
+      "default": false
+    },
     "stripTokens": {
-      "title": "Strip tokens",
+      "title": "Strip Tokens",
       "description": "Remove any Authorization header or token query parameter before forwarding traffic to the Service.",
       "type": "boolean"
     },
@@ -26,13 +32,13 @@
       "type": "string"
     },
     "realmCertificateString": {
-      "title": "Keycloak realm certificate",
+      "title": "Keycloak Realm Certificate",
       "description": "To validate OAuth requests. Must be a PEM-encoded X.509 certificate, including bounding strings.",
       "type": "string",
       "format": "textarea"
     },
     "forwardAuthInfo": {
-      "title": "Forward Keycloak token information",
+      "title": "Forward Keycloak Token Information",
       "description":  "Fields from the token can be set as headers and forwarded to the Service. Access_token corresponds to the full token.",
       "type": "array",
       "format": "table",
@@ -60,7 +66,6 @@
           }
         }
       }
-
     }
   }
 }

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -25,8 +25,8 @@ import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.PolicyFailureType;
 import io.apiman.gateway.engine.beans.ServiceRequest;
-import io.apiman.gateway.engine.components.IDataStoreComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.components.ISharedStateComponent;
 import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
@@ -74,10 +74,10 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
             if (config.getRequireTransportSecurity() && !request.isTransportSecure()) {
                 // If we've detected a situation where we should blacklist a token
                 if (config.getBlacklistUnsafeTokens()) {
-                    blacklistToken(context, rawToken, new IAsyncResultHandler<Boolean>() {
+                    blacklistToken(context, rawToken, new IAsyncResultHandler<Void>() {
 
                         @Override
-                        public void handle(IAsyncResult<Boolean> result) {
+                        public void handle(IAsyncResult<Void> result) {
                             if (result.isError()) {
                                 chain.throwError(result.getError());
                             } else {
@@ -201,20 +201,20 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
 
     private void isBlacklistedToken(IPolicyContext context, String rawToken,
             final IAsyncResultHandler<Boolean> resultHandler) {
-        IDataStoreComponent dataStore = getDataStore(context);
+        ISharedStateComponent dataStore = getDataStore(context);
         dataStore.<Boolean> getProperty("apiman-keycloak-blacklist", rawToken, false, //$NON-NLS-1$
                 resultHandler);
     }
 
     private void blacklistToken(IPolicyContext context, String rawToken,
-            final IAsyncResultHandler<Boolean> resultHandler) {
-        IDataStoreComponent dataStore = getDataStore(context);
+            final IAsyncResultHandler<Void> resultHandler) {
+        ISharedStateComponent dataStore = getDataStore(context);
         dataStore.<Boolean> setProperty("apiman-keycloak-blacklist", rawToken, true, //$NON-NLS-1$
                 resultHandler);
     }
 
-    private IDataStoreComponent getDataStore(IPolicyContext context) {
-        return context.getComponent(IDataStoreComponent.class);
+    private ISharedStateComponent getDataStore(IPolicyContext context) {
+        return context.getComponent(ISharedStateComponent.class);
     }
 
     private IPolicyFailureFactoryComponent getFailureFactory(IPolicyContext context) {

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -66,8 +66,10 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
         if (rawToken == null) {
             if (config.getRequireOauth()) {
                 chain.doFailure(noAuthenticationProvidedFailure(context));
-                return;
+            } else {
+                chain.doApply(request);
             }
+            return;
         } else {
             if (config.getRequireTransportSecurity() && !request.isTransportSecure()) {
                 // If we've detected a situation where we should blacklist a token
@@ -105,7 +107,7 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
                 });
                 return;
             }
-            
+       
             doTokenAuth(request, context, config, chain, rawToken);
         }
     }

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/KeycloakOauthConfigBean.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/KeycloakOauthConfigBean.java
@@ -31,6 +31,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.keycloak.util.PemUtils;
+import org.omg.PortableInterceptor.TRANSPORT_RETRY;
 
 /**
  * KeyCloak OAuth Policy Configuration
@@ -39,8 +40,8 @@ import org.keycloak.util.PemUtils;
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({ "requireOauth", "blacklistUnsafeTokens", "stripTokens", "realm",
-        "realmCertificateString", "forwardAuthInfo" })
+@JsonPropertyOrder({ "requireOauth", "requireTransportSecurity", "blacklistUnsafeTokens", 
+    "stripTokens", "realm", "realmCertificateString", "forwardAuthInfo" })
 public class KeycloakOauthConfigBean {
 
     /**
@@ -50,6 +51,16 @@ public class KeycloakOauthConfigBean {
      */
     @JsonProperty("requireOauth")
     private Boolean requireOauth = true;
+    
+    /**
+     * Require Transport Security
+     * <p>
+     * OAuth2 requires transport security such as TLS or SSL in order to be secure.
+     * Terminate request if none provided.
+     */
+    @JsonProperty("requireTransportSecurity")
+    private boolean requireTransportSecurity;
+    
     /**
      * Blacklist unsafe tokens
      * <p>
@@ -91,6 +102,7 @@ public class KeycloakOauthConfigBean {
     private Map<String, Object> additionalProperties = new HashMap<>();
     private Certificate realmCertificate;
 
+
     /**
      * Require OAuth
      * <p>
@@ -106,13 +118,37 @@ public class KeycloakOauthConfigBean {
     /**
      * Require OAuth
      * <p>
-     * Terminate request if no OAuth is provided.
-     * 
+     * Any request used without transport security will be rejected. OAuth2 requires transport security (e.g.
+     * TLS, SSL) to provide protection against replay attacks. It is strongly advised for this option to be
+     * switched on.
+     *  
      * @param requireOauth The requireOauth
      */
     @JsonProperty("requireOauth")
     public void setRequireOauth(Boolean requireOauth) {
         this.requireOauth = requireOauth;
+    }
+
+    /**
+     * Require Transport Security
+     * <p>
+     * Any request used without transport security will be rejected. OAuth2 requires transport security (e.g.
+     * TLS, SSL) to provide protection against replay attacks. It is strongly advised for this option to be
+     * switched on.
+     * 
+     * @return whether transport security is required
+     */
+    @JsonProperty("requireTransportSecurity")
+    public boolean getRequireTransportSecurity() {
+        return requireTransportSecurity;
+    }
+    
+    /**
+     * @param requireTransportSecurity status
+     */
+    @JsonProperty("requireTransportSecurity")
+    public void setRequireTransportSecurity(boolean requireTransportSecurity) {
+        this.requireTransportSecurity = requireTransportSecurity;
     }
 
     /**

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/KeycloakOauthConfigBean.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/KeycloakOauthConfigBean.java
@@ -31,7 +31,6 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.keycloak.util.PemUtils;
-import org.omg.PortableInterceptor.TRANSPORT_RETRY;
 
 /**
  * KeyCloak OAuth Policy Configuration

--- a/keycloak-oauth-policy/src/main/resources/io/apiman/plugins/keycloak_oauth_policy/messages.properties
+++ b/keycloak-oauth-policy/src/main/resources/io/apiman/plugins/keycloak_oauth_policy/messages.properties
@@ -1,1 +1,3 @@
-KeycloakOauthPolicy.no_token_given=OAuth 'Authorization' header or 'access_token' query parameter must be provided.
+KeycloakOauthPolicy.NoTokenGiven=OAuth2 'Authorization' header or 'access_token' query parameter must be provided.
+KeycloakOauthPolicy.NoTransportSecurity=OAuth2 token was transmitted without required transport security (TLS, SSL).
+KeycloakOauthPolicy.BlacklistedToken=Token was used insecurely in previous request and was blacklisted to prevent replay attacks.

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.ServiceRequest;
-import io.apiman.gateway.engine.components.IDataStoreComponent;
 import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.components.ISharedStateComponent;
 import io.apiman.gateway.engine.impl.DefaultPolicyFailureFactoryComponent;
-import io.apiman.gateway.engine.impl.InMemoryDataStoreComponent;
+import io.apiman.gateway.engine.impl.InMemorySharedStateComponent;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
 import io.apiman.plugins.keycloak_oauth_policy.beans.KeycloakOauthConfigBean;
@@ -57,14 +57,10 @@ public class KeycloakOauthPolicyTest {
 
     private static X509Certificate[] idpCertificates;
     private static KeyPair idpPair;
-    private static KeyPair badPair;
-    private static KeyPair clientPair;
-    private static X509Certificate[] clientCertificateChain;
     private AccessToken token;
     private KeycloakOauthPolicy keycloakOauthPolicy;
     private KeycloakOauthConfigBean config;
     private ServiceRequest serviceRequest;
-    private InMemoryDataStoreComponent imDataStoreComponent;
 
     @Mock
     private IPolicyChain<ServiceRequest> mChain;
@@ -94,12 +90,8 @@ public class KeycloakOauthPolicyTest {
     @BeforeClass
     public static void setupCerts() throws NoSuchAlgorithmException, InvalidKeyException,
             NoSuchProviderException, SignatureException {
-        badPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         idpPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         idpCertificates = new X509Certificate[] { generateTestCertificate("CN=IDP", "CN=IDP", idpPair) };
-        clientPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
-        clientCertificateChain = new X509Certificate[] { generateTestCertificate("CN=Client", "CN=IDP",
-                idpPair) };
     }
 
     @Before
@@ -121,11 +113,11 @@ public class KeycloakOauthPolicyTest {
 
         // Set up components.
         // Failure factory
-        given(mContext.getComponent(IPolicyFailureFactoryComponent.class)).willReturn(
-                new DefaultPolicyFailureFactoryComponent());
+        given(mContext.getComponent(IPolicyFailureFactoryComponent.class)).
+            willReturn(new DefaultPolicyFailureFactoryComponent());
         // Data store
-        imDataStoreComponent = new InMemoryDataStoreComponent();
-        given(mContext.getComponent(IDataStoreComponent.class)).willReturn(imDataStoreComponent);
+        given(mContext.getComponent(ISharedStateComponent.class)).
+            willReturn(new InMemorySharedStateComponent());
     }
 
     private String setupValidRequest() throws CertificateEncodingException, IOException {


### PR DESCRIPTION
I thought these changes would only take 10 minutes to do. Several hours later, I have this!

The features described in the schema are now all implemented. If the plugin is called without transport security, if set, the request will be rejected; if set, the rejected token will be blacklisted globally in order to prevent replay attacks.

It uses the changes I made in this PR: https://github.com/apiman/apiman/pull/88

Important note: I had to update the apiman dependency to 1.1.0-SNAPSHOT, so we either need to do a release or support snapshots in some way (or can we chain the CI builds so it does apiman main project first?).
