### PR TITLE
Apiman 353

### DIFF
--- a/jsonp-policy/pom.xml
+++ b/jsonp-policy/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apiman.plugins</groupId>
+    <artifactId>apiman-plugins</artifactId>
+    <version>1.1.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>apiman-plugins-jsonp-policy</artifactId>
+  <packaging>war</packaging>
+  <name>apiman-plugins-jsonp-policy</name>
+
+  <dependencies>
+    <!-- apiman dependencies (must be excluded from the WAR) -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-policies</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webResources>
+            <resource>
+              <directory>src/main/apiman</directory>
+              <targetPath>META-INF/apiman</targetPath>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jsonp-policy/src/main/apiman/plugin.json
+++ b/jsonp-policy/src/main/apiman/plugin.json
@@ -1,0 +1,6 @@
+{
+  "frameworkVersion" : 1.0,
+  "name" : "JSONP Policy Plugin",
+  "description" : "This plugin turns an endpoint into a JSONP compatible endpoint.",
+  "version" : "${project.version}"
+}

--- a/jsonp-policy/src/main/apiman/policyDefs/jsonp-policyDef.json
+++ b/jsonp-policy/src/main/apiman/policyDefs/jsonp-policyDef.json
@@ -1,0 +1,9 @@
+{
+  "id" : "jsonp-policy",
+  "name" : "JSONP Policy",
+  "description" : "Turns an endpoint into a JSONP compatible endpoint.",
+  "policyImpl" : "plugin:${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}/io.apiman.plugins.jsonp_policy.JsonpPolicy",
+  "icon" : "bars",
+  "formType" : "JsonSchema",
+  "form" : "schemas/jsonp-policyDef.schema"
+}

--- a/jsonp-policy/src/main/apiman/policyDefs/schemas/jsonp-policyDef.schema
+++ b/jsonp-policy/src/main/apiman/policyDefs/schemas/jsonp-policyDef.schema
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSONP Policy Configuration",
+  "type": "object",
+  "properties": {
+    "callbackParamName": {
+      "title": "Callback Parameter Name",
+      "description": "Parameter name used to specify the callback function.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "default": "callback"
+    }
+  }
+}

--- a/jsonp-policy/src/main/java/io/apiman/plugins/jsonp_policy/JsonpPolicy.java
+++ b/jsonp-policy/src/main/java/io/apiman/plugins/jsonp_policy/JsonpPolicy.java
@@ -1,0 +1,91 @@
+package io.apiman.plugins.jsonp_policy;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.io.AbstractStream;
+import io.apiman.gateway.engine.io.ByteBuffer;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.IReadWriteStream;
+import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
+import io.apiman.gateway.engine.policy.IDataPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.plugins.jsonp_policy.beans.JsonpConfigBean;
+
+/**
+ * Policy that turns an endpoint into a JSONP compatible endpoint. It removes the callback
+ * function param from the request and uses it to wrap the response. The content type is set
+ * to <code>application/javascript</code>.    
+ * 
+ * @see <a href="http://en.wikipedia.org/wiki/JSONP" target="_blank">JSONP - Wikipedia</a>
+ * 
+ * @author Alexandre Kieling <alex.kieling@gmail.com>
+ */
+public class JsonpPolicy extends AbstractMappedPolicy<JsonpConfigBean> implements IDataPolicy {
+
+    private static final String OPEN_PARENTHESES = "(";
+    private static final String CLOSE_PARENTHESES = ")";
+	static final String CALLBACK_FUNCTION_NAME = "callbackFunctionName";
+
+    @Override
+    protected Class<JsonpConfigBean> getConfigurationClass() {
+        return JsonpConfigBean.class;
+    }
+
+    @Override
+    protected void doApply(ServiceRequest request, IPolicyContext context, JsonpConfigBean config,
+            IPolicyChain<ServiceRequest> chain) {
+        String callbackParamName = config.getCallbackParamName();
+        if (callbackParamName != null) {
+        	String callbackFunctionName = request.getQueryParams().remove(callbackParamName);
+        	if (callbackFunctionName != null) {
+        		context.setAttribute(CALLBACK_FUNCTION_NAME, callbackFunctionName);
+        	}
+        }
+        super.doApply(request, context, config, chain);
+    }
+    
+    @Override
+    public IReadWriteStream<ServiceRequest> getRequestDataHandler(ServiceRequest request, IPolicyContext context) {
+        return null;
+    }
+    
+    @Override
+    public IReadWriteStream<ServiceResponse> getResponseDataHandler(final ServiceResponse response, 
+            IPolicyContext context) {
+        final String callbackFunctionName = (String) context.getAttribute(CALLBACK_FUNCTION_NAME, null);
+        
+        if (callbackFunctionName != null) {
+        	response.getHeaders().put("Content-Type", "application/javascript");
+        	
+            return new AbstractStream<ServiceResponse>() {
+
+                @Override
+                public ServiceResponse getHead() {
+                    return response;
+                }
+
+                @Override
+                protected void handleHead(ServiceResponse head) {
+                }
+                
+                @Override
+                public void write(IApimanBuffer chunk) {
+                	StringBuilder response = new StringBuilder();
+                	response.append(callbackFunctionName);
+                	response.append(OPEN_PARENTHESES);
+                	response.append(chunk.toString());
+                	response.append(CLOSE_PARENTHESES);
+                	byte[] bytes = response.toString().getBytes();
+
+                    IApimanBuffer newChunk = new ByteBuffer(bytes.length);
+                    newChunk.append(bytes);
+                    
+                    super.write(newChunk);
+                }
+                
+            };
+        }
+        return null;
+    }
+}

--- a/jsonp-policy/src/main/java/io/apiman/plugins/jsonp_policy/beans/JsonpConfigBean.java
+++ b/jsonp-policy/src/main/java/io/apiman/plugins/jsonp_policy/beans/JsonpConfigBean.java
@@ -1,0 +1,28 @@
+package io.apiman.plugins.jsonp_policy.beans;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Configuration object for the JSONP policy.
+ *
+ * @author Alexandre Kieling <alex.kieling@gmail.com>
+ */
+public class JsonpConfigBean {
+
+	@JsonProperty
+    private String callbackParamName;
+
+    /**
+     * @return the parameter name used to specify the callback function 
+     */
+    public String getCallbackParamName() {
+        return callbackParamName;
+    }
+
+    /**
+     * @param callbackParamName the parameter name used to specify the callback function
+     */
+    public void setCallbackParamName(String callbackParamName) {
+        this.callbackParamName = callbackParamName;
+    }
+}

--- a/jsonp-policy/src/test/java/io/apiman/plugins/jsonp_policy/JsonpPolicyTest.java
+++ b/jsonp-policy/src/test/java/io/apiman/plugins/jsonp_policy/JsonpPolicyTest.java
@@ -1,0 +1,128 @@
+package io.apiman.plugins.jsonp_policy;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import io.apiman.gateway.engine.async.IAsyncHandler;
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.io.ByteBuffer;
+import io.apiman.gateway.engine.io.IApimanBuffer;
+import io.apiman.gateway.engine.io.IReadWriteStream;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.gateway.engine.policy.PolicyContextImpl;
+import io.apiman.plugins.jsonp_policy.beans.JsonpConfigBean;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JsonpPolicyTest {
+
+    private JsonpPolicy jsonpPolicy;
+    
+    @Before
+    public void setUp() {
+        jsonpPolicy = new JsonpPolicy();
+    }
+    
+    @Test
+    public void testParseEmptyConfiguration() {
+        // given
+        String config = "{}";
+        // when
+        JsonpConfigBean jsonpConfig = jsonpPolicy.parseConfiguration(config);
+        // then
+        assertNull(jsonpConfig.getCallbackParamName());
+    }
+
+    @Test
+    public void testParseRealConfiguration() {
+        // given
+        String parameterName = "jsonp";
+        String config = "{\"callbackParamName\":\"" + parameterName + "\"}";
+        // when
+        JsonpConfigBean jsonpConfig = jsonpPolicy.parseConfiguration(config);
+        // then
+        assertEquals(parameterName, jsonpConfig.getCallbackParamName());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldSaveCallbackParamNameInContext() throws Exception {
+        // given
+        JsonpConfigBean config = new JsonpConfigBean();
+        config.setCallbackParamName("testParam");
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("testParam", "testFunction");
+        ServiceRequest request = new ServiceRequest();
+        request.setQueryParams(queryParams);
+        IPolicyContext context = new PolicyContextImpl(null);
+        IPolicyChain<ServiceRequest> chain = mock(IPolicyChain.class);
+        // when
+        jsonpPolicy.doApply(request, context, config, chain);
+        // then
+        assertEquals("testFunction", context.getAttribute("callbackFunctionName", null));
+        verify(chain).doApply(request);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldRemoveCallbackParamNameFromRequest() throws Exception {
+        // given
+        JsonpConfigBean config = new JsonpConfigBean();
+        config.setCallbackParamName("testParam");
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("testParam", "testFunction");
+        ServiceRequest request = new ServiceRequest();
+        request.setQueryParams(queryParams);
+        IPolicyContext context = new PolicyContextImpl(null);
+        IPolicyChain<ServiceRequest> chain = mock(IPolicyChain.class);
+        // when
+        jsonpPolicy.doApply(request, context, config, chain);
+        // then
+        assertNull(request.getQueryParams().get("testParam"));
+        verify(chain).doApply(request);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void changeResponseWhenCallbackParamNameIsSavedInContext() throws Exception {
+        // given
+        IPolicyContext context = new PolicyContextImpl(null);
+        String functionName = "testFunction";
+		context.setAttribute(JsonpPolicy.CALLBACK_FUNCTION_NAME, functionName);
+        ServiceResponse response = new ServiceResponse();
+        String json = "{\"name\": \"test\"}";
+        IApimanBuffer chunk = new ByteBuffer(json.getBytes().length);
+        chunk.append(json);
+        IAsyncHandler<IApimanBuffer> bodyHandler = mock(IAsyncHandler.class);
+        // when
+        IReadWriteStream<ServiceResponse> responseDataHandler = jsonpPolicy.getResponseDataHandler(response, context);
+        ServiceResponse head = responseDataHandler.getHead();
+        responseDataHandler.bodyHandler(bodyHandler);
+        responseDataHandler.write(chunk);
+        // then
+        assertSame(response, head);
+        String javascript = "testFunction(" + json + ")";
+        int newChunkSize = javascript.getBytes().length;
+        IApimanBuffer newChunk = new ByteBuffer(newChunkSize);
+        newChunk.append(javascript);
+        verify(bodyHandler).handle(refEq(newChunk));
+    }
+
+    @Test
+    public void doNotChangeResponseWhenCallbackParamNameIsNotSavedInContext() throws Exception {
+        // given
+        IPolicyContext context = new PolicyContextImpl(null);
+        ServiceResponse response = new ServiceResponse();
+        // when
+        IReadWriteStream<ServiceResponse> responseDataHandler = jsonpPolicy.getResponseDataHandler(response, context);
+        // then
+        assertNull(responseDataHandler);
+    }
+    
+}

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
     <module>keycloak-oauth-policy</module>
     <module>http-security-policy</module>
     <module>simple-header-policy</module>
+    <module>jsonp-policy</module>
   </modules>
 
   <build>


### PR DESCRIPTION
JSONP policy currently supporting only JSON responses.
I'm using a StringBuilder to change the response. I believe that can be improved in the future when the insert methods of io.apiman.gateway.engine.io.ByteBuffer are implemented.
