### PR TITLE
Use static annotation processing of @JsonProperty, and introspection to look up token claims.

### DIFF
--- a/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
+++ b/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
@@ -80,7 +80,7 @@
     },
     "forwardAuthInfo": {
       "title": "Forward Keycloak Token Information",
-      "description": "Fields from the token can be set as headers and forwarded to the API. Access_token corresponds to the full token.",
+      "description": "Fields from the token can be set as headers and forwarded to the API. All <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims\" target=\"_blank\">standard claims</a>, custom claims and <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#IDToken\" target=\"_blank\">ID token fields</a> are available (case sensitive). A special value of <strong><tt>token</tt></strong> will forward the entire encoded token. Nested claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>, <tt>address.formatted</tt>)",
       "type": "array",
       "format": "table",
       "items": {
@@ -95,17 +95,20 @@
           },
           "field": {
             "title": "Field",
-            "type": "string",
-            "enum": [
-              "subject",
-              "username",
-              "email",
-              "name",
-              "access_token"
-            ]
+            "type": "string"
           }
         }
-      }
+      },
+      "links": [
+      	{
+          "href": "https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims",
+          "rel": "Specification: All standard claims and their descriptions. This includes name, preferred_username, email, etc."
+      	},
+      	{
+          "href": "https://openid.net/specs/openid-connect-basic-1_0.html#IDToken",
+          "rel": "Specification: Standard ID token fields"
+      	}
+      ]
     }
   }
 }

--- a/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
+++ b/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
@@ -80,7 +80,7 @@
     },
     "forwardAuthInfo": {
       "title": "Forward Keycloak Token Information",
-      "description": "Fields from the token can be set as headers and forwarded to the API. All <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims\" target=\"_blank\">standard claims</a>, custom claims and <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#IDToken\" target=\"_blank\">ID token fields</a> are available (case sensitive). A special value of <strong><tt>token</tt></strong> will forward the entire encoded token. Nested claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>, <tt>address.formatted</tt>)",
+      "description": "Fields from the token can be set as headers and forwarded to the API. All <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims\" target=\"_blank\">standard claims</a>, custom claims and <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#IDToken\" target=\"_blank\">ID token fields</a> are available (case sensitive). A special value of <strong><tt>access_token</tt></strong> will forward the entire encoded token. Nested claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>, <tt>address.formatted</tt>)",
       "type": "array",
       "format": "table",
       "items": {

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/ClaimLookup.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/ClaimLookup.java
@@ -41,6 +41,9 @@ public class ClaimLookup {
         do {
             getProperties(clazz, "", new ArrayDeque<Field>());
         } while ((clazz = clazz.getSuperclass()) != null);
+        // Legacy mappings, to ensure old configs keep working
+        STANDARD_CLAIMS_FIELD_MAP.put("username", STANDARD_CLAIMS_FIELD_MAP.get(IDToken.PREFERRED_USERNAME));
+        STANDARD_CLAIMS_FIELD_MAP.put("subject", STANDARD_CLAIMS_FIELD_MAP.get("sub"));
     }
 
     private static void getProperties(Class<?> klazz, String path, Deque<Field> fieldChain) {

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/ClaimLookup.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/ClaimLookup.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.plugins.keycloak_oauth_policy;
+
+import java.util.Map;
+
+import org.keycloak.representations.AddressClaimSet;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.JsonWebToken;
+
+/**
+* @author Marc Savy {@literal <msavy@redhat.com>}
+*/
+@SuppressWarnings("nls")
+public class ClaimLookup {
+
+    public static String lookupClaim(IDToken token, String key) {
+        if (key == null || token == null)
+            return null;
+
+        switch(key) {
+        case IDToken.NONCE:
+            return token.getNonce();
+        case IDToken.SESSION_STATE:
+            return token.getSessionState();
+        case IDToken.NAME:
+            return token.getName();
+        case IDToken.GIVEN_NAME:
+            return token.getGivenName();
+        case IDToken.FAMILY_NAME:
+            return token.getFamilyName();
+        case IDToken.MIDDLE_NAME:
+            return token.getMiddleName();
+        case IDToken.NICKNAME: //Not consistent, so we can't reliably look up with introspection.
+            return token.getNickName();
+        case IDToken.PREFERRED_USERNAME:
+            return token.getPreferredUsername();
+        case IDToken.PROFILE:
+            return token.getProfile();
+        case IDToken.PICTURE:
+            return token.getPicture();
+        case IDToken.WEBSITE:
+            return token.getWebsite();
+        case IDToken.EMAIL:
+            return token.getEmail();
+        case IDToken.EMAIL_VERIFIED:
+            return token.getEmailVerified().toString();
+        case IDToken.GENDER:
+            return token.getGender();
+        case IDToken.BIRTHDATE:
+            return token.getBirthdate();
+        case IDToken.ZONEINFO:
+            return token.getZoneinfo();
+        case IDToken.LOCALE:
+            return token.getLocale();
+        case IDToken.PHONE_NUMBER:
+            return token.getPhoneNumber();
+        case IDToken.PHONE_NUMBER_VERIFIED:
+            return token.getPhoneNumber();
+        case IDToken.ADDRESS: // Would be useless otherwise, i think
+            return token.getAddress().getFormattedAddress().toString();
+        case IDToken.ADDRESS + "." + AddressClaimSet.COUNTRY:
+            return token.getAddress().getCountry();
+        case IDToken.ADDRESS + "." + AddressClaimSet.FORMATTED:
+            return token.getAddress().getFormattedAddress();
+        case IDToken.ADDRESS + "." + AddressClaimSet.LOCALITY:
+            return token.getAddress().getLocality();
+        case IDToken.ADDRESS + "." + AddressClaimSet.POSTAL_CODE:
+            return token.getAddress().getPostalCode();
+        case IDToken.ADDRESS + "." + AddressClaimSet.REGION:
+            return token.getAddress().getRegion();
+        case IDToken.ADDRESS + "." + AddressClaimSet.STREET_ADDRESS:
+            return token.getAddress().getStreetAddress();
+        case IDToken.UPDATED_AT:
+            return token.getUpdatedAt().toString();
+        case IDToken.CLAIMS_LOCALES:
+            return token.getClaimsLocales();
+        default:
+            return getOtherClaimValue(token, key).toString();
+        }
+    }
+
+    @SuppressWarnings("unchecked") // KC code - thanks.
+    private static Object getOtherClaimValue(JsonWebToken token, String claim) {
+        String[] split = claim.split("\\.");
+        Map<String, Object> jsonObject = token.getOtherClaims();
+        for (int i = 0; i < split.length; i++) {
+            if (i == split.length - 1) {
+                return jsonObject.get(split[i]);
+            } else {
+                Object val = jsonObject.get(split[i]);
+                if (!(val instanceof Map))
+                    return null;
+                jsonObject = (Map<String, Object>) val;
+            }
+        }
+        return null;
+    }
+}

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -15,19 +15,10 @@
  */
 package io.apiman.plugins.keycloak_oauth_policy;
 
-import java.util.Collections;
-
-import org.apache.commons.lang.StringUtils;
-import org.keycloak.RSATokenVerifier;
-import org.keycloak.VerificationException;
-import org.keycloak.constants.KerberosConstants;
-import org.keycloak.representations.AccessToken;
-import org.keycloak.representations.AccessToken.Access;
-
 import io.apiman.gateway.engine.async.IAsyncResult;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
-import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.components.ISharedStateComponent;
 import io.apiman.gateway.engine.metrics.RequestMetric;
 import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
@@ -39,6 +30,15 @@ import io.apiman.plugins.keycloak_oauth_policy.beans.ForwardAuthInfo;
 import io.apiman.plugins.keycloak_oauth_policy.beans.KeycloakOauthConfigBean;
 import io.apiman.plugins.keycloak_oauth_policy.failures.PolicyFailureFactory;
 import io.apiman.plugins.keycloak_oauth_policy.util.Holder;
+
+import java.util.Collections;
+
+import org.apache.commons.lang.StringUtils;
+import org.keycloak.RSATokenVerifier;
+import org.keycloak.VerificationException;
+import org.keycloak.constants.KerberosConstants;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessToken.Access;
 
 /**
  * A Keycloak OAuth policy.

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -208,11 +208,16 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
     private void forwardHeaders(ApiRequest request, KeycloakOauthConfigBean config, String rawToken,
             AccessToken parsedToken) {
         for (ForwardAuthInfo entry : config.getForwardAuthInfo()) {
-            String headerValue = entry.getField().toLowerCase().equals("token") ? rawToken : //$NON-NLS-1$
+            String headerValue = isToken(entry.getField()) ? rawToken :
                 ClaimLookup.getClaim(parsedToken, entry.getField());
             // Add the header if we've been able to look it up, else it'll just be empty.
             request.getHeaders().put(entry.getHeader(), headerValue);
         }
+    }
+
+    @SuppressWarnings("nls")
+    private boolean isToken(String field) {
+        return field.toLowerCase().equals("access_token");
     }
 
     private void isBlacklistedToken(IPolicyContext context, String rawToken,

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -216,6 +216,7 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
             } catch (IllegalArgumentException | IllegalAccessException e) {
                 // TODO log error. This shouldn't occur, but if it somehow does we need to know.
                 System.err.println("Unexpected error looking up token field: " + e); //$NON-NLS-1$
+                e.printStackTrace(System.err);
             }
         }
     }

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicy.java
@@ -208,16 +208,10 @@ public class KeycloakOauthPolicy extends AbstractMappedPolicy<KeycloakOauthConfi
     private void forwardHeaders(ApiRequest request, KeycloakOauthConfigBean config, String rawToken,
             AccessToken parsedToken) {
         for (ForwardAuthInfo entry : config.getForwardAuthInfo()) {
-            try {
-                String headerValue = entry.getField().toLowerCase().equals("token") ? rawToken : //$NON-NLS-1$
-                    ClaimLookup.getClaim(parsedToken, entry.getField());
-                // Add the header if we've been able to look it up, else it'll just be empty.
-                request.getHeaders().put(entry.getHeader(), headerValue);
-            } catch (IllegalArgumentException | IllegalAccessException e) {
-                // TODO log error. This shouldn't occur, but if it somehow does we need to know.
-                System.err.println("Unexpected error looking up token field: " + e); //$NON-NLS-1$
-                e.printStackTrace(System.err);
-            }
+            String headerValue = entry.getField().toLowerCase().equals("token") ? rawToken : //$NON-NLS-1$
+                ClaimLookup.getClaim(parsedToken, entry.getField());
+            // Add the header if we've been able to look it up, else it'll just be empty.
+            request.getHeaders().put(entry.getHeader(), headerValue);
         }
     }
 

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/ForwardAuthInfo.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/ForwardAuthInfo.java
@@ -17,7 +17,9 @@ package io.apiman.plugins.keycloak_oauth_policy.beans;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.annotation.Generated;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -114,12 +116,29 @@ public class ForwardAuthInfo {
 
     @Generated("org.jsonschema2pojo")
     public static enum Field {
-
-        SUBJECT("subject"), //$NON-NLS-1$
-        USERNAME("username"), //$NON-NLS-1$
-        EMAIL("email"), //$NON-NLS-1$
-        NAME("name"), //$NON-NLS-1$
-        ACCESS_TOKEN("access_token"); //$NON-NLS-1$
+        ACCESS_TOKEN("token"),
+        NONCE("nonce"),
+        SESSION_STATE("session_state"),
+        NAME("name"),
+        GIVEN_NAME("given_name"),
+        FAMILY_NAME("family_name"),
+        MIDDLE_NAME("middle_name"),
+        NICKNAME("nickname"),
+        PREFERRED_USERNAME("preferred_username"),
+        PROFILE("profile"),
+        PICTURE("picture"),
+        WEBSITE("website"),
+        EMAIL("email"),
+        EMAIL_VERIFIED("email_verified"),
+        GENDER("gender"),
+        BIRTHDATE("birthdate"),
+        ZONEINFO("zoneinfo"),
+        LOCALE("locale"),
+        PHONE_NUMBER("phone_number"),
+        PHONE_NUMBER_VERIFIED("phone_number_verified"),
+        ADDRESS("address"),
+        UPDATED_AT("updated_at"),
+        CLAIMS_LOCALES("claims_locales");
         private final String value;
         private static Map<String, ForwardAuthInfo.Field> constants = new HashMap<>();
 

--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/ForwardAuthInfo.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/beans/ForwardAuthInfo.java
@@ -18,18 +18,14 @@ package io.apiman.plugins.keycloak_oauth_policy.beans;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Generated;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.codehaus.jackson.annotate.JsonAnyGetter;
 import org.codehaus.jackson.annotate.JsonAnySetter;
-import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
-import org.codehaus.jackson.annotate.JsonValue;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
@@ -45,7 +41,7 @@ public class ForwardAuthInfo {
     private String headers;
 
     @JsonProperty("field")
-    private ForwardAuthInfo.Field field;
+    private String field;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -69,7 +65,7 @@ public class ForwardAuthInfo {
      * @return The field
      */
     @JsonProperty("field")
-    public ForwardAuthInfo.Field getField() {
+    public String getField() {
         return field;
     }
 
@@ -77,7 +73,7 @@ public class ForwardAuthInfo {
      * @param field The field
      */
     @JsonProperty("field")
-    public void setField(ForwardAuthInfo.Field field) {
+    public void setField(String field) {
         this.field = field;
     }
 
@@ -112,62 +108,6 @@ public class ForwardAuthInfo {
         ForwardAuthInfo rhs = ((ForwardAuthInfo) other);
         return new EqualsBuilder().append(headers, rhs.headers).append(field, rhs.field)
                 .append(additionalProperties, rhs.additionalProperties).isEquals();
-    }
-
-    @Generated("org.jsonschema2pojo")
-    public static enum Field {
-        ACCESS_TOKEN("token"),
-        NONCE("nonce"),
-        SESSION_STATE("session_state"),
-        NAME("name"),
-        GIVEN_NAME("given_name"),
-        FAMILY_NAME("family_name"),
-        MIDDLE_NAME("middle_name"),
-        NICKNAME("nickname"),
-        PREFERRED_USERNAME("preferred_username"),
-        PROFILE("profile"),
-        PICTURE("picture"),
-        WEBSITE("website"),
-        EMAIL("email"),
-        EMAIL_VERIFIED("email_verified"),
-        GENDER("gender"),
-        BIRTHDATE("birthdate"),
-        ZONEINFO("zoneinfo"),
-        LOCALE("locale"),
-        PHONE_NUMBER("phone_number"),
-        PHONE_NUMBER_VERIFIED("phone_number_verified"),
-        ADDRESS("address"),
-        UPDATED_AT("updated_at"),
-        CLAIMS_LOCALES("claims_locales");
-        private final String value;
-        private static Map<String, ForwardAuthInfo.Field> constants = new HashMap<>();
-
-        static {
-            for (ForwardAuthInfo.Field c : values()) {
-                constants.put(c.value, c);
-            }
-        }
-
-        private Field(String value) {
-            this.value = value;
-        }
-
-        @JsonValue
-        @Override
-        public String toString() {
-            return this.value;
-        }
-
-        @JsonCreator
-        public static ForwardAuthInfo.Field fromValue(String value) {
-            ForwardAuthInfo.Field constant = constants.get(value);
-            if (constant == null) {
-                throw new IllegalArgumentException(value);
-            } else {
-                return constant;
-            }
-        }
-
     }
 
 }

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyLegacyTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyLegacyTest.java
@@ -1,0 +1,188 @@
+package io.apiman.plugins.keycloak_oauth_policy;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.components.ISharedStateComponent;
+import io.apiman.gateway.engine.impl.DefaultPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.impl.InMemorySharedStateComponent;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.plugins.keycloak_oauth_policy.beans.ForwardAuthInfo;
+import io.apiman.plugins.keycloak_oauth_policy.beans.ForwardRoles;
+import io.apiman.plugins.keycloak_oauth_policy.beans.KeycloakOauthConfigBean;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.bouncycastle.x509.X509V1CertificateGenerator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessToken.Access;
+import org.keycloak.util.Time;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Test the {@link KeycloakOauthPolicy}.
+ *
+ * With thanks to the Keycloak project for their RSAVerifierTest whose setup procedures are adapted here for
+ * our requirements.
+ *
+ * @author Marc Savy {@literal <msavy@redhat.com>}
+ */
+@SuppressWarnings({ "nls", "deprecation" })
+public class KeycloakOauthPolicyLegacyTest {
+
+    private static X509Certificate[] idpCertificates;
+    private static KeyPair idpPair;
+    private AccessToken token;
+    private KeycloakOauthPolicy keycloakOauthPolicy;
+    private KeycloakOauthConfigBean config;
+    private ApiRequest apiRequest;
+
+    @Mock
+    private IPolicyChain<ApiRequest> mChain;
+    @Mock
+    private IPolicyContext mContext;
+    private ForwardRoles forwardRoles;
+
+    static {
+        if (Security.getProvider("BC") == null)
+            Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public static X509Certificate generateTestCertificate(String subject, String issuer, KeyPair pair)
+            throws InvalidKeyException, NoSuchProviderException, SignatureException {
+        X509V1CertificateGenerator certGen = new X509V1CertificateGenerator();
+
+        certGen.setSerialNumber(BigInteger.valueOf(System.currentTimeMillis()));
+        certGen.setIssuerDN(new X500Principal(issuer));
+        certGen.setNotBefore(new Date(System.currentTimeMillis() - 10000));
+        certGen.setNotAfter(new Date(System.currentTimeMillis() + 10000));
+        certGen.setSubjectDN(new X500Principal(subject));
+        certGen.setPublicKey(pair.getPublic());
+        certGen.setSignatureAlgorithm("SHA256WithRSAEncryption");
+
+        return certGen.generateX509Certificate(pair.getPrivate(), "BC");
+    }
+
+    @BeforeClass
+    public static void setupCerts() throws NoSuchAlgorithmException, InvalidKeyException,
+            NoSuchProviderException, SignatureException {
+        idpPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        idpCertificates = new X509Certificate[] { generateTestCertificate("CN=IDP", "CN=IDP", idpPair) };
+    }
+
+    @Before
+    public void initTest() {
+        MockitoAnnotations.initMocks(this);
+
+        token = new AccessToken();
+
+        AccessToken realm = token.subject("CN=Client").issuer("apiman-realm"); // KC seems to use issuer for realm?
+
+        realm.addAccess("apiman-api").addRole("apiman-gateway-user-role").addRole("a-nother-role");
+        realm.setRealmAccess(new Access().addRole("lets-use-a-realm-role"));
+
+        keycloakOauthPolicy = new KeycloakOauthPolicy();
+        config = new KeycloakOauthConfigBean();
+        config.setRequireOauth(true);
+        config.setStripTokens(false);
+        config.setBlacklistUnsafeTokens(false);
+        config.setRequireTransportSecurity(false);
+
+        forwardRoles = new ForwardRoles();
+        config.setForwardRoles(forwardRoles);
+
+        apiRequest = new ApiRequest();
+
+        // Set up components.
+        // Failure factory
+        given(mContext.getComponent(IPolicyFailureFactoryComponent.class)).
+            willReturn(new DefaultPolicyFailureFactoryComponent());
+        // Data store
+        given(mContext.getComponent(ISharedStateComponent.class)).
+            willReturn(new InMemorySharedStateComponent());
+    }
+
+    private String generateAndSerializeToken() throws CertificateEncodingException, IOException {
+        token.notBefore(Time.currentTime() - 100);
+
+        config.setRealm("apiman-realm");
+        config.setRealmCertificateString(certificateAsPem(idpCertificates[0]));
+
+        return new JWSBuilder().jsonContent(token).rsa256(idpPair.getPrivate());
+    }
+
+    @Test
+    public void subjectToSub() throws CertificateEncodingException, IOException {
+        ForwardAuthInfo authInfo = new ForwardAuthInfo();
+        authInfo.setHeaders("X-TEST");
+        authInfo.setField("subject");
+        config.getForwardAuthInfo().add(authInfo);
+
+        token.setSubject("anse-georgette");
+        String encoded = generateAndSerializeToken();
+        apiRequest.getHeaders().put("Authorization", "Bearer " + encoded);
+        keycloakOauthPolicy.apply(apiRequest, mContext, config, mChain);
+
+        verify(mChain).doApply(apiRequest);
+
+        Assert.assertEquals("anse-georgette", apiRequest.getHeaders().get("X-TEST"));
+    }
+
+    @Test
+    public void usernameToPreferredUsername() throws CertificateEncodingException, IOException {
+        ForwardAuthInfo authInfo = new ForwardAuthInfo();
+        authInfo.setHeaders("X-TEST");
+        authInfo.setField("username");
+        config.getForwardAuthInfo().add(authInfo);
+
+        token.setPreferredUsername("anse-lazio");
+        String encoded = generateAndSerializeToken();
+        apiRequest.getHeaders().put("Authorization", "Bearer " + encoded);
+        keycloakOauthPolicy.apply(apiRequest, mContext, config, mChain);
+
+        verify(mChain).doApply(apiRequest);
+
+        Assert.assertEquals("anse-lazio", apiRequest.getHeaders().get("X-TEST"));
+    }
+
+    private String certificateAsPem(X509Certificate x509) throws CertificateEncodingException, IOException {
+        StringWriter sw = new StringWriter();
+        PemWriter writer = new PemWriter(sw);
+        PemObject pemObject = new PemObject("CERTIFICATE", x509.getEncoded());
+        try {
+            writer.writeObject(pemObject);
+            writer.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            writer.close();
+        }
+        return sw.toString();
+    }
+}

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
@@ -17,7 +17,6 @@ import io.apiman.gateway.engine.policies.AuthorizationPolicy;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
 import io.apiman.plugins.keycloak_oauth_policy.beans.ForwardAuthInfo;
-import io.apiman.plugins.keycloak_oauth_policy.beans.ForwardAuthInfo.Field;
 import io.apiman.plugins.keycloak_oauth_policy.beans.ForwardRoles;
 import io.apiman.plugins.keycloak_oauth_policy.beans.KeycloakOauthConfigBean;
 
@@ -303,7 +302,7 @@ public class KeycloakOauthPolicyTest {
     public void shouldForwardAuthInfoName() throws CertificateEncodingException, IOException {
         ForwardAuthInfo authInfo = new ForwardAuthInfo();
         authInfo.setHeaders("X-TEST");
-        authInfo.setField(Field.USERNAME);
+        authInfo.setField("preferred_username");
         config.getForwardAuthInfo().add(authInfo);
 
         token.setPreferredUsername("ABC");
@@ -317,10 +316,26 @@ public class KeycloakOauthPolicyTest {
     }
 
     @Test
+    public void shouldForwardToken() throws CertificateEncodingException, IOException {
+        ForwardAuthInfo authInfo = new ForwardAuthInfo();
+        authInfo.setHeaders("X-TEST");
+        authInfo.setField("token");
+        config.getForwardAuthInfo().add(authInfo);
+
+        String encoded = generateAndSerializeToken();
+        apiRequest.getHeaders().put("Authorization", "Bearer " + encoded);
+        keycloakOauthPolicy.apply(apiRequest, mContext, config, mChain);
+
+        verify(mChain).doApply(apiRequest);
+
+        Assert.assertEquals(encoded, apiRequest.getHeaders().get("X-TEST"));
+    }
+
+    @Test
     public void shouldForwardAuthInfoSubject() throws CertificateEncodingException, IOException {
         ForwardAuthInfo authInfo = new ForwardAuthInfo();
         authInfo.setHeaders("X-TEST");
-        authInfo.setField(Field.EMAIL);
+        authInfo.setField("email");
         config.getForwardAuthInfo().add(authInfo);
 
         token.setEmail("apiman@apiman.io");

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
@@ -353,10 +353,44 @@ public class KeycloakOauthPolicyTest {
     }
 
     @Test
-    public void shouldBeNullForInvalidFieldLookup()  throws CertificateEncodingException, IOException {
+    public void shouldBeNullForInvalidNestedClaimLookup()  throws CertificateEncodingException, IOException {
         ForwardAuthInfo authInfo = new ForwardAuthInfo();
         authInfo.setHeaders("X-TEST");
         authInfo.setField("address.street_address");
+        config.getForwardAuthInfo().add(authInfo);
+        // Do *not* set street address
+
+        String encoded = generateAndSerializeToken();
+        apiRequest.getHeaders().put("Authorization", "Bearer " + encoded);
+        keycloakOauthPolicy.apply(apiRequest, mContext, config, mChain);
+
+        verify(mChain).doApply(apiRequest);
+
+        Assert.assertEquals(null, apiRequest.getHeaders().get("X-TEST"));
+    }
+
+    @Test
+    public void shouldBeNullForInvalidOtherClaimLookup()  throws CertificateEncodingException, IOException {
+        ForwardAuthInfo authInfo = new ForwardAuthInfo();
+        authInfo.setHeaders("X-TEST");
+        authInfo.setField("xxx");
+        config.getForwardAuthInfo().add(authInfo);
+        // Do *not* set street address
+
+        String encoded = generateAndSerializeToken();
+        apiRequest.getHeaders().put("Authorization", "Bearer " + encoded);
+        keycloakOauthPolicy.apply(apiRequest, mContext, config, mChain);
+
+        verify(mChain).doApply(apiRequest);
+
+        Assert.assertEquals(null, apiRequest.getHeaders().get("X-TEST"));
+    }
+
+    @Test
+    public void shouldBeNullForUnsetStandardClaimLookup()  throws CertificateEncodingException, IOException {
+        ForwardAuthInfo authInfo = new ForwardAuthInfo();
+        authInfo.setHeaders("X-TEST");
+        authInfo.setField("email");
         config.getForwardAuthInfo().add(authInfo);
         // Do *not* set street address
 

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyTest.java
@@ -320,7 +320,7 @@ public class KeycloakOauthPolicyTest {
     public void shouldForwardToken() throws CertificateEncodingException, IOException {
         ForwardAuthInfo authInfo = new ForwardAuthInfo();
         authInfo.setHeaders("X-TEST");
-        authInfo.setField("token");
+        authInfo.setField("access_token");
         config.getForwardAuthInfo().add(authInfo);
 
         String encoded = generateAndSerializeToken();


### PR DESCRIPTION
We should discuss this before we merge it, but I've come up with a solution to https://issues.jboss.org/browse/APIMAN-834 which is flexible and gets around a very tricky problem in KC token parsing.

The implementation of the KC IDToken is such that once standard claims (special token fields) are parsed, they are deleted from the claims map - hence you can't do a simple map lookup for them. They are instead held in specifically named and `@JsonProperty` annotated variables.  

Previously I was holding hand-maintained mappings (in multiple places) of string names to token `get` method call so that, for instance "email" mapped "token.getEmail()", etc. This is inflexible, because if new fields are added, we won't know about them, and it didn't support custom claims (which are obviously impossible to add pre-populated drop-down menus for, anyway). 

Standard introspection would be fragile, because it would rely on naming conventions being obeyed perfectly (which they aren't in one or two places).

Instead I came up with the idea of reusing the `@JsonProperty` annotations which are on all `IDToken` claims and are carefully maintained by KC to ensure the token serializes/deserializes properly. So it is robust and is mapped to the spec's variable names.

In summary, the algorithm is:
- Statically index all `@JsonProperty` labelled fields in `IDToken` and all ancestors.
- Map annotation provided `name` to field. This provides a robust mapping from field name to variables.
- If a given variable itself contains `@JsonProperty` annotations, then index it also. The name in this case will be joined with a dot at each level of depth (e.g. `address.street_address`).
- At runtime, it is now trivially simple to look up the requested claims via the 'standard' claims index, then falling back to the 'other' claims index. Woohoo!

This approach has several benefits:
- If the KC team add new fields (e.g. new spec), we will automatically be able to access them without doing anything.
- Do not need to manually maintain extensive claims lists in Enum, Schema, etc
- Can look up standard and custom claims with equal ease
- Has better performance than turning the token back into JSON and re-parsing it, which is what some internal bits of KC seem to do

![image](https://cloud.githubusercontent.com/assets/423513/11829105/fbe8ed16-a391-11e5-8ed1-2d1fc55bff40.png)

Result:

```
  "headers" : {
    "a" : "dda64ec0-ecf0-46d7-9688-a7677f196b5b",
    "b" : "admin@admin.com",
    "c" : "admin",
    "Accept" : "*/*",
    "User-Agent" : "curl/7.43.0",
    "Connection" : "Keep-Alive",
    "Host" : "localhost:8080",
    "Accept-Encoding" : "gzip",
    "token" : "<snip>"
  },
  "bodyLength" : null,
  "bodySha1" : null,
```
