### PR TITLE
APIMAN-897 Adding a simple log policy

### DIFF
--- a/log-policy/pom.xml
+++ b/log-policy/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apiman.plugins</groupId>
+    <artifactId>apiman-plugins</artifactId>
+    <version>1.1.10-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>apiman-plugins-log-policy</artifactId>
+  <packaging>war</packaging>
+  <name>apiman-plugins-log-policy</name>
+
+  <dependencies>
+    <!-- apiman dependencies (must be excluded from the WAR) -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+	<dependency>
+		<groupId>io.apiman</groupId>
+		<artifactId>apiman-test-policies</artifactId>
+		<scope>test</scope>
+	</dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webResources>
+            <resource>
+              <directory>src/main/apiman</directory>
+              <targetPath>META-INF/apiman</targetPath>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/log-policy/src/main/apiman/plugin.json
+++ b/log-policy/src/main/apiman/plugin.json
@@ -1,0 +1,6 @@
+{
+  "frameworkVersion" : 1.0,
+  "name" : "Log Policy Plugin",
+  "description" : "This plugin has policies for logging to std out.",
+  "version" : "${project.version}"
+}

--- a/log-policy/src/main/apiman/policyDefs/log-headers-policyDef.json
+++ b/log-policy/src/main/apiman/policyDefs/log-headers-policyDef.json
@@ -1,0 +1,7 @@
+{
+  "id" : "log-headers-policy",
+  "name" : "Log Headers Policy",
+  "description" : "A policy that logs the headers to std out.  Useful to analyse inbound HTTP traffic to the gateway when added as the first policy in the chain or to analyse outbound HTTP traffic from the gateway when added as the last policy in the chain.",
+  "policyImpl" : "plugin:${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}/io.apiman.plugins.log_policy.LogHeadersPolicy",
+  "icon" : "fire"
+}

--- a/log-policy/src/main/java/io/apiman/plugins/log_policy/LogHeadersPolicy.java
+++ b/log-policy/src/main/java/io/apiman/plugins/log_policy/LogHeadersPolicy.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.log_policy;
+
+import java.util.Map;
+
+import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.apiman.gateway.engine.beans.ServiceResponse;
+import io.apiman.gateway.engine.beans.exceptions.ConfigurationParseException;
+import io.apiman.gateway.engine.policy.IPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+/**
+ * A policy that logs the headers of the HTTP request and HTTP response at the current position in the chain.
+ *
+ * @author ton.swieb@finalist.nl
+ */
+public class LogHeadersPolicy implements IPolicy {
+
+	private static enum HttpDirection {
+		REQUEST("HTTP Request"), 
+		RESPONSE("HTTP Response");
+		
+		private final String description;
+		
+		HttpDirection(String descr) {
+			this.description = descr;
+		}
+		
+		String getDescription() {
+			return description;
+		}		
+	};
+	
+	public static final String ENDPOINT_ATTRIBUTE="LogHeadersPolicy_EndpointAttribute";
+	
+    /**
+     * Constructor.
+     */
+    public LogHeadersPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#parseConfiguration(java.lang.String)
+     */
+    @Override
+    public Object parseConfiguration(String jsonConfiguration) throws ConfigurationParseException {
+        return null;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceRequest request, IPolicyContext context, Object config,
+            IPolicyChain<ServiceRequest> chain) {
+    	
+    	String endpoint = request.getService().getEndpoint();
+    	context.setAttribute(ENDPOINT_ATTRIBUTE, endpoint);
+    	logHeaders(request.getHeaders(),HttpDirection.REQUEST, endpoint);
+        chain.doApply(request);
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policy.IPolicy#apply(io.apiman.gateway.engine.beans.ServiceResponse, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    public void apply(ServiceResponse response, IPolicyContext context, Object config,
+            IPolicyChain<ServiceResponse> chain) {
+    	
+    	String endpoint = context.getAttribute(ENDPOINT_ATTRIBUTE,"");
+    	logHeaders(response.getHeaders(),HttpDirection.RESPONSE,endpoint);
+        chain.doApply(response);
+    }
+
+	private void logHeaders(final Map<String, String> headers, final HttpDirection direction, final String endpoint) {
+		
+		System.out.println(String.format("Logging %d %s headers for %s", headers.size(), direction.getDescription(), endpoint));
+    	for (String key : headers.keySet()) {
+    		System.out.println(String.format("Key : %s, Value : %s", key, headers.get(key)));
+    	}
+	}
+
+}

--- a/log-policy/src/test/java/io/apiman/plugins/log_policy/LogHeadersPolicyTest.java
+++ b/log-policy/src/test/java/io/apiman/plugins/log_policy/LogHeadersPolicyTest.java
@@ -1,0 +1,42 @@
+package io.apiman.plugins.log_policy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.apiman.test.common.mock.EchoResponse;
+import io.apiman.test.policies.ApimanPolicyTest;
+import io.apiman.test.policies.Configuration;
+import io.apiman.test.policies.PolicyFailureError;
+import io.apiman.test.policies.PolicyTestRequest;
+import io.apiman.test.policies.PolicyTestRequestType;
+import io.apiman.test.policies.PolicyTestResponse;
+import io.apiman.test.policies.TestingPolicy;
+
+@TestingPolicy(LogHeadersPolicy.class)
+public class LogHeadersPolicyTest extends ApimanPolicyTest {
+
+	/**
+	 * A simple happy flow test to verify the policy does not blow up in our face.
+	 */
+	@Test
+	@Configuration("{}")
+	public void testLogHeadersWithoutAnyRequestHeaders() throws PolicyFailureError, Throwable {
+		
+		PolicyTestResponse response = send(PolicyTestRequest.build(PolicyTestRequestType.GET, "/some/resource"));
+		Assert.assertEquals(200, response.code());
+	}
+	
+	/**
+	 * A simple happy flow test to verify the policy does not blow up in our face.
+	 */
+	@Test
+	@Configuration("{}")
+	public void testLogHeadersHappyFlow() throws PolicyFailureError, Throwable {
+		
+		PolicyTestResponse response = send(PolicyTestRequest.build(PolicyTestRequestType.GET, "/some/resource")
+				.header("X-Test-Name", "testGet"));
+		Assert.assertEquals(200, response.code());
+		EchoResponse entity = response.entity(EchoResponse.class);
+		Assert.assertEquals("testGet", entity.getHeaders().get("X-Test-Name"));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@
     <module>simple-header-policy</module>
     <module>test-policy</module>
     <module>transformation-policy</module>
+    <module>log-policy</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Hi,

As a first attempt for https://issues.jboss.org/browse/APIMAN-897 I create a very simple log policy for the 1.1.x branch.
Could you add it to the main project? It would make it a lot easier to use the plugin from within apiman.
Thanks.

Regards,

Ton
