### PR TITLE
Temporarily back out changes to bouncycastle scope due to complex dep…

### DIFF
--- a/keycloak-oauth-policy/pom.xml
+++ b/keycloak-oauth-policy/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <scope>test</scope>
+      <!-- <scope>test</scope> -->
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,6 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${version.org.bouncycastle}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.iharder</groupId>


### PR DESCRIPTION
There's an issue which I hope to resolve soon (going to consult various Maven gurus). But am rolling back the recent changes to prevent runtime breakage.

Essentially `keycloak-common` requires bouncycastle as a dep, but `apiman-plugins` only needs it as a `test` scope. However, it seems that specifying it as test in only apiman makes it unavailable to `keycloak-common` for some reason.

BTW labelling it as test scope in `apiman-plugins/pom.xml` was a mistake, but doesn't impact the situation.  The culprit seems to be `keycloak-oauth-policy/pom.xml`.

/cc @jcechace 
