### PR TITLE
re #931 SOAP Authorization Policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,15 @@
         <role>Developer</role>
       </roles>
     </developer>
+    <developer>
+      <name>Rachel Yordan</name>
+      <id>kahboom</id>
+      <email>ryordan@redhat.com</email>
+      <organization>Red Hat</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
   </developers>
 
   <properties>
@@ -236,6 +245,7 @@
     <module>keycloak-oauth-policy</module>
     <module>noop-policy</module>
     <module>simple-header-policy</module>
+    <module>soap-authorization-policy</module>
     <module>test-policy</module>
     <module>transformation-policy</module>
     <module>log-policy</module>

--- a/soap-authorization-policy/pom.xml
+++ b/soap-authorization-policy/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apiman.plugins</groupId>
+    <artifactId>apiman-plugins</artifactId>
+    <version>1.2.2-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>apiman-plugins-soap-authorization-policy</artifactId>
+  <packaging>war</packaging>
+  <name>apiman-plugins-soap-authorization-policy</name>
+
+  <dependencies>
+    <!-- apiman dependencies (must be excluded from the WAR) -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-policies</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
+    
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-beans</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-test-policies</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
+    <dependency>
+    	<groupId>io.apiman</groupId>
+    	<artifactId>apiman-test-common</artifactId>
+    	<scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webResources>
+            <resource>
+              <directory>src/main/apiman</directory>
+              <targetPath>META-INF/apiman</targetPath>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/soap-authorization-policy/src/main/apiman/plugin.json
+++ b/soap-authorization-policy/src/main/apiman/plugin.json
@@ -1,0 +1,6 @@
+{
+	"frameworkVersion": 1.0,
+	"name": "SOAP Authorization Policy Plugin",
+	"description": "An implementation of our out-of-the-box Authorization Policy Plugin, with the difference that this one accepts a single SOAPAction field in the request header.",
+	"version": "${project.version}"
+}

--- a/soap-authorization-policy/src/main/apiman/policyDefs/schemas/soap-authorization-PolicyDef.schema
+++ b/soap-authorization-policy/src/main/apiman/policyDefs/schemas/soap-authorization-PolicyDef.schema
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "SOAP Authorization Policy Configuration",
+  "type": "object",
+  "options": {
+    "disable_collapse": true
+  },
+  "properties": {
+    "rules": {
+      "title": "Add Authorization Rule",
+      "description": "Manage the list of fine-grained authorization rules in the box below. If you want a single required role to protect your entire API, simply add one item with a path of \".*\" and an action of \"*\".",
+      "type": "array",
+      "format": "table",
+      "items": {
+        "type": "object",
+        "title": "Rule",
+        "properties": {
+          "pathPattern": {
+            "title": "Path",
+            "type": "string"
+          },
+          "action": {
+            "title": "SOAPAction",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "multiMatch": {
+      "title": "Should the request pass when any or all of the authorization rules pass?",
+      "type": "string",
+      "id": "multiMatch",
+      "enum": [
+        "all",
+        "any"
+      ]
+    },
+    "requestUnmatched": {
+      "title": "If the request does not match any of the authorization rules, should it pass or fail?",
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    }
+  }
+}

--- a/soap-authorization-policy/src/main/apiman/policyDefs/soap-authorization-policyDef.json
+++ b/soap-authorization-policy/src/main/apiman/policyDefs/soap-authorization-policyDef.json
@@ -1,0 +1,15 @@
+{
+  "id" : "soap-authorization-policy",
+  "name" : "SOAP Authorization Policy",
+  "description" : "Enables fine grained authorization to API resources based on authenticated user roles. Allows a single SOAPAction in the header.",
+  "policyImpl" : "plugin:${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}/io.apiman.plugins.soap_authorization_policy.SoapAuthorizationPolicy",
+  "icon" : "code",
+  "formType" : "JsonSchema",
+  "templates" : [
+    {
+      "language" : null,
+      "template" : "Appropriate authorization roles are required.  There are @{rules.size()} authorization rules defined."
+    }
+  ],
+  "form" : "schemas/soap-authorization-policyDef.schema"
+}

--- a/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationConfig.java
+++ b/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.soap_authorization_policy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.apiman.gateway.engine.policies.config.MultipleMatchType;
+import io.apiman.gateway.engine.policies.config.UnmatchedRequestType;
+
+
+/**
+ * Configuration object for the Authorization policy.
+ */
+public class SoapAuthorizationConfig {
+
+    private List<SoapAuthorizationRule> rules = new ArrayList<>();
+    private UnmatchedRequestType requestUnmatched;
+    private MultipleMatchType multiMatch;
+
+    /**
+     * Constructor.
+     */
+    public SoapAuthorizationConfig() {
+    }
+
+    /**
+     * @return the rules
+     */
+    public List<SoapAuthorizationRule> getRules() {
+        return rules;
+    }
+
+    /**
+     * @param rules the rules to set
+     */
+    public void setRules(List<SoapAuthorizationRule> rules) {
+        this.rules = rules;
+    }
+
+    /**
+     * @return the requestUnmatched
+     */
+    public UnmatchedRequestType getRequestUnmatched() {
+        return requestUnmatched;
+    }
+
+    /**
+     * @param requestUnmatched the requestUnmatched to set
+     */
+    public void setRequestUnmatched(UnmatchedRequestType requestUnmatched) {
+        this.requestUnmatched = requestUnmatched;
+    }
+
+    /**
+     * @return the multiMatch
+     */
+    public MultipleMatchType getMultiMatch() {
+        return multiMatch;
+    }
+
+    /**
+     * @param multiMatch the multiMatch to set
+     */
+    public void setMultiMatch(MultipleMatchType multiMatch) {
+        this.multiMatch = multiMatch;
+    }
+
+}

--- a/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicy.java
+++ b/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicy.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.plugins.soap_authorization_policy;
+
+import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.gateway.engine.components.IPolicyFailureFactoryComponent;
+import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
+import io.apiman.gateway.engine.policies.PolicyFailureCodes;
+import io.apiman.gateway.engine.policies.config.MultipleMatchType;
+import io.apiman.gateway.engine.policies.config.UnmatchedRequestType;
+import io.apiman.gateway.engine.policies.i18n.Messages;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Adds authorization capabilities to apiman. This policy allows users to
+ * specify what roles the authenticated user must have in order to be allowed to
+ * call the API.
+ *
+ * This policy works in conjunction with a compatible Authentication policy,
+ * such as the Basic authentication policy.  The assumption is that such a
+ * policy will extract the roles from the source of identity (either during
+ * authentication or as a followup step).  These roles will be stored in the
+ * policy context for use by this Authorization policy.  The roles are
+ * represented as a simple set of strings.
+ *
+ * @author eric.wittmann@redhat.com
+ * @author rachel.yordan@redhat.com
+ */
+public class SoapAuthorizationPolicy extends AbstractMappedPolicy<SoapAuthorizationConfig> {
+
+    public static final String AUTHENTICATED_USER_ROLES = "io.apiman.policies.auth::authenticated-user-roles"; //$NON-NLS-1$
+    public static final String HEADER_SOAP_ACTION = "SOAPAction";
+
+    public SoapAuthorizationPolicy() {
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#getConfigurationClass()
+     */
+    @Override
+    protected Class<SoapAuthorizationConfig> getConfigurationClass() {
+        return SoapAuthorizationConfig.class;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#doApply(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    protected void doApply(ApiRequest request, IPolicyContext context, SoapAuthorizationConfig config,
+            IPolicyChain<ApiRequest> chain) {
+        Set<String> userRoles = context.getAttribute(AUTHENTICATED_USER_ROLES, (HashSet<String>) null);
+        String action = request.getHeaders().get(HEADER_SOAP_ACTION);
+        String resource = request.getDestination();
+
+        // If no roles are set in the context - then fail with a configuration error
+        if (userRoles == null) {
+            String msg = Messages.i18n.format("SoapAuthorizationPolicy.MissingRoles"); //$NON-NLS-1$
+            PolicyFailure failure = context.getComponent(IPolicyFailureFactoryComponent.class).createFailure(
+                    PolicyFailureType.Other, PolicyFailureCodes.CONFIGURATION_ERROR, msg);
+            chain.doFailure(failure);
+            return;
+        }
+
+        if (isAuthorized(config, action, resource, userRoles)) {
+            chain.doApply(request);
+        } else {
+            String msg = Messages.i18n.format("SoapAuthorizationPolicy.Unauthorized"); //$NON-NLS-1$
+            PolicyFailure failure = context.getComponent(IPolicyFailureFactoryComponent.class).createFailure(
+                    PolicyFailureType.Authorization, PolicyFailureCodes.USER_NOT_AUTHORIZED, msg);
+            chain.doFailure(failure);
+        }
+    }
+
+    /**
+     * Checks the action and resource against the requirements configured for the
+     * policy.  Returns true if the user has all of the required roles (multiple
+     * roles may be required depending on configuration).
+     *
+     * Note that if the configuration does not include any
+     *
+     * @param config
+     * @param action
+     * @param resource
+     * @param userRoles
+     */
+    private boolean isAuthorized(SoapAuthorizationConfig config, String action, String resource, Set<String> userRoles) {
+        if (resource == null || resource.trim().length() == 0) {
+            resource = "/"; //$NON-NLS-1$
+        }
+        // If multiMatch is set to 'any', then start out with authorized = false, and we need to
+        // find at least one match to turn authorized to true.  If it's set to "all" (the default)
+        // then start out authorized, and it requires *every* matching rule to pass or else it'll
+        // switch to false.
+        boolean authorized = true;
+        if (config.getMultiMatch() == MultipleMatchType.any) {
+            authorized = false;
+        }
+        boolean matchFound = false;
+        for (SoapAuthorizationRule soapAuthorizationRule : config.getRules()) {
+            boolean actionMatches = "*".equals(soapAuthorizationRule.getAction()) || action.equalsIgnoreCase(soapAuthorizationRule.getAction()); //$NON-NLS-1$
+            boolean ruleMatches = resource.matches(soapAuthorizationRule.getPathPattern());
+            if (actionMatches && ruleMatches) {
+                // the action and resource matched the rule - so enforce the role here!
+                boolean userHasRole = userRoles.contains(soapAuthorizationRule.getRole());
+                matchFound = true;
+
+                // If the multiMatch setting is "at least one matching rule" then do a logical
+                // OR operation.  If it's set to "all matching rules" then do a logical AND.
+                if (config.getMultiMatch() == MultipleMatchType.any) {
+                    authorized = authorized || userHasRole;
+                } else {
+                    authorized = authorized && userHasRole;
+                }
+            }
+        }
+
+        // If no authorization rules matched the request, what do we do?
+        if (!matchFound) {
+            if (config.getRequestUnmatched() == UnmatchedRequestType.pass) {
+                authorized = true;
+            } else {
+                authorized = false;
+            }
+        }
+
+        return authorized;
+    }
+
+}

--- a/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationRule.java
+++ b/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationRule.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.soap_authorization_policy;
+
+/**
+ * A single authorization rule consisting of an action, path pattern, and role name.
+ *
+ * @author eric.wittmann@redhat.com
+ * @author rachel.yordan@redhat.com
+ */
+public class SoapAuthorizationRule {
+
+    private String action;
+    private String pathPattern;
+    private String role;
+
+    public SoapAuthorizationRule() {
+    }
+
+    /**
+     * @return the action
+     */
+    public String getAction() {
+        return action;
+    }
+
+    /**
+     * @param action
+     */
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    /**
+     * @return pathPattern
+     */
+    public String getPathPattern() {
+        return pathPattern;
+    }
+
+    /**
+     * @param pathPattern
+     */
+    public void setPathPattern(String pathPattern) {
+        this.pathPattern = pathPattern;
+    }
+
+    /**
+     * @return role
+     */
+    public String getRole() {
+        return role;
+    }
+
+    /**
+     * @param role
+     */
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        SoapAuthorizationRule rule2 = (SoapAuthorizationRule) obj;
+        return this.getAction().equals(rule2.getAction()) && this.getPathPattern().equals(rule2.getPathPattern())
+                && this.getRole().equals(rule2.getRole());
+    }
+
+}

--- a/soap-authorization-policy/src/test/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicyConfigTest.java
+++ b/soap-authorization-policy/src/test/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicyConfigTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apiman.plugins.soap_authorization_policy;
+
+import io.apiman.gateway.engine.policies.config.MultipleMatchType;
+import io.apiman.gateway.engine.policies.config.UnmatchedRequestType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test
+ *
+ * @author rubenrm1@gmail.com
+ * @author rachel.yordan@redhat.com
+ * Test the {@link SoapAuthorizationConfig}.
+ *
+ */
+
+@SuppressWarnings({ "nls" })
+
+public class SoapAuthorizationPolicyConfigTest {
+
+    @Test
+    public void testParseConfiguration() {
+        SoapAuthorizationPolicy policy = new SoapAuthorizationPolicy();
+
+        String config = "{}";
+        Object parsed = policy.parseConfiguration(config);
+        SoapAuthorizationConfig parsedConfig = (SoapAuthorizationConfig) parsed;
+        
+        Assert.assertNotNull(parsed);
+        Assert.assertEquals(SoapAuthorizationConfig.class, parsed.getClass());
+       
+        Assert.assertNotNull(parsedConfig.getRules());
+        Assert.assertTrue(parsedConfig.getRules().isEmpty());
+    }
+    
+    
+    @Test
+    public void testSinglePath() {
+        SoapAuthorizationPolicy policy = new SoapAuthorizationPolicy();
+
+        String config = "{}";
+        Object parsed = policy.parseConfiguration(config);
+        SoapAuthorizationConfig parsedConfig = (SoapAuthorizationConfig) parsed;
+        
+        config = "{\r\n" +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \".*\", \"role\" : \"role-1\" }\r\n" +
+                "  ]\r\n" +
+                "}";
+        parsed = policy.parseConfiguration(config);
+        parsedConfig = (SoapAuthorizationConfig) parsed;
+        Assert.assertNotNull(parsedConfig.getRules());
+        
+        SoapAuthorizationRule rule1 = new SoapAuthorizationRule();
+        rule1.setAction("reportIncident");
+        rule1.setPathPattern(".*");
+        rule1.setRole("role-1");
+        List<SoapAuthorizationRule> expectedConfiguration = Arrays.asList(rule1);
+        Assert.assertEquals(expectedConfiguration, parsedConfig.getRules());
+    }
+    
+    
+    @Test
+    public void testMultiplePaths() {
+        SoapAuthorizationPolicy policy = new SoapAuthorizationPolicy();
+
+        String config = "{}";
+        Object parsed = policy.parseConfiguration(config);
+        SoapAuthorizationConfig parsedConfig = (SoapAuthorizationConfig) parsed;
+        
+        config = "{\r\n" +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \".*\", \"role\" : \"role-1\" },\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \".+\", \"role\" : \"role-2\" },\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"(.*)\", \"role\" : \"role-3\" }\r\n" +
+                "  ]\r\n" +
+                "}";
+        parsed = policy.parseConfiguration(config);
+        parsedConfig = (SoapAuthorizationConfig) parsed;
+        Assert.assertNotNull(parsedConfig.getRules());
+        
+        SoapAuthorizationRule rule1 = new SoapAuthorizationRule();
+        rule1.setAction("reportIncident");
+        rule1.setPathPattern(".*");
+        rule1.setRole("role-1");
+        List<SoapAuthorizationRule> expectedConfiguration = Arrays.asList(rule1);
+        
+        expectedConfiguration = new ArrayList<>();
+        SoapAuthorizationRule rule2 = new SoapAuthorizationRule();
+        rule2.setAction("reportIncident");
+        rule2.setPathPattern(".+");
+        rule2.setRole("role-2");
+        SoapAuthorizationRule rule3 = new SoapAuthorizationRule();
+        rule3.setAction("reportIncident");
+        rule3.setPathPattern("(.*)");
+        rule3.setRole("role-3");
+        expectedConfiguration.add(rule1);
+        expectedConfiguration.add(rule2);
+        expectedConfiguration.add(rule3);
+        Assert.assertEquals(expectedConfiguration, parsedConfig.getRules());
+    }
+    
+    
+    @Test
+    public void testBooleanFlags() {
+        SoapAuthorizationPolicy policy = new SoapAuthorizationPolicy();
+
+        String config = "{}";
+        Object parsed = policy.parseConfiguration(config);
+        SoapAuthorizationConfig parsedConfig = (SoapAuthorizationConfig) parsed;
+        
+        config = "{\r\n" +
+                "    \"requestUnmatched\" : \"pass\",\r\n" +
+                "    \"multiMatch\" : \"any\"\r\n" +
+                "}\r\n" +
+                "";
+        parsed = policy.parseConfiguration(config);
+        parsedConfig = (SoapAuthorizationConfig) parsed;
+        Assert.assertEquals(Collections.emptyList(), parsedConfig.getRules());
+        Assert.assertEquals(MultipleMatchType.any, parsedConfig.getMultiMatch());
+        Assert.assertEquals(UnmatchedRequestType.pass, parsedConfig.getRequestUnmatched());
+    }
+
+}

--- a/soap-authorization-policy/src/test/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicyTest.java
+++ b/soap-authorization-policy/src/test/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicyTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.plugins.soap_authorization_policy;
+
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.test.common.mock.EchoResponse;
+import io.apiman.test.policies.ApimanPolicyTest;
+import io.apiman.test.policies.Configuration;
+import io.apiman.test.policies.PolicyFailureError;
+import io.apiman.test.policies.PolicyTestRequest;
+import io.apiman.test.policies.PolicyTestRequestType;
+import io.apiman.test.policies.PolicyTestResponse;
+import io.apiman.test.policies.TestingPolicy;
+
+import java.util.HashSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Unit test
+ *
+ * @author rubenrm1@gmail.com
+ * @author rachel.yordan@redhat.com
+ * Test the {@link SoapAuthorizationPolicy}.
+ *
+ */
+
+@TestingPolicy(SoapAuthorizationPolicy.class)
+@SuppressWarnings({ "nls" })
+
+public class SoapAuthorizationPolicyTest extends ApimanPolicyTest {
+
+    @Test
+    @Configuration("{\r\n" +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \".*\", \"role\" : \"role-1\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testSimple() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+        userRoles.add("role-1");
+        
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/invoices/1");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                " \"requestUnmatched\" : \"pass\"," +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/auth/.*\", \"role\" : \"the-role\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testPath() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+        userRoles.add("other-role");
+        
+        // Should Fail
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/auth/my-items");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+            Assert.assertEquals(PolicyFailureType.Authorization, policyFailure.getType());
+            Assert.assertEquals(10009, policyFailure.getFailureCode());
+        }
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/unauth/my-items");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                " \"requestUnmatched\" : \"pass\"," +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"/auth/.*\", \"role\" : \"the-role\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testAction() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+        userRoles.add("other-role");
+        
+        
+        // Should Succeed
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/auth/my-items");
+        request.header("SOAPAction", "closeIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+        
+        
+        // Should Fail
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/auth/my-items");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+            Assert.assertEquals(PolicyFailureType.Authorization, policyFailure.getType());
+        }
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/.*\", \"role\" : \"user\" },\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/admin/.*\", \"role\" : \"admin\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testMultiple() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+        userRoles.add("user");
+     
+        // Should Succeed
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/path/to/user/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+      
+     
+        // Should Fail
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/admin/path/to/admin/resource");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+            Assert.assertEquals(PolicyFailureType.Authorization, policyFailure.getType());
+        }
+        
+        //
+
+        userRoles.add("admin");
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/path/to/user/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        response = send(request);
+        echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+        
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/admin/path/to/admin/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        response = send(request);
+        echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                " \"requestUnmatched\" : \"pass\"," +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"/user/.*\", \"role\" : \"user\" },\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"/admin/.*\", \"role\" : \"admin\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testNoneMatchedPass() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+
+        // Should Succeed
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/other/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+        
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.PUT, "/admin/resource");
+        request.header("SOAPAction", "closedIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        response = send(request);
+        echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                " \"requestUnmatched\" : \"fail\"," +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"/user/.*\", \"role\" : \"user\" },\r\n" +
+                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"/admin/.*\", \"role\" : \"admin\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testNoneMatchedFail() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+     
+        // Should Fail
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/other/resource");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+            Assert.assertEquals(PolicyFailureType.Authorization, policyFailure.getType());
+        }
+        
+     
+        // Should Fail
+        request = PolicyTestRequest.build(PolicyTestRequestType.POST, "/admin/resource");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+        }
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                " \"multiMatch\" : \"any\"," +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/.*\", \"role\" : \"user\" },\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/multi/.*\", \"role\" : \"role-1\" },\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/multi/.*\", \"role\" : \"role-2\" },\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/admin/.*\", \"role\" : \"admin\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testMultipleAnyMatch() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+        userRoles.add("other-role");
+        
+        // Should Fail
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/multi/resource");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+        }
+        
+
+        userRoles.add("role-1");
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/multi/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+
+        
+        userRoles.add("role-2");
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/multi/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        response = send(request);
+        echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+    }
+
+    @Test
+    @Configuration("{\r\n" +
+                " \"multiMatch\" : \"all\"," +
+                "  \"rules\" : [\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/multi/.*\", \"role\" : \"role-1\" },\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/multi/.*\", \"role\" : \"role-2\" },\r\n" +
+                "    { \"action\" : \"*\", \"pathPattern\" : \"/admin/.*\", \"role\" : \"admin\" }\r\n" +
+                "  ]\r\n" +
+                "}")
+    public void testMultipleAllMatch() throws Throwable {
+        HashSet<String> userRoles = new HashSet<>();
+        userRoles.add("other-role");
+        
+        // Should Fail
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/multi/resource");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+            Assert.assertEquals(PolicyFailureType.Authorization, policyFailure.getType()); // Expected <Authorization> but was <Other>
+        }
+
+        userRoles.add("role-1");
+        
+        // Should Fail
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/multi/resource");
+        
+        try {
+            request.header("SOAPAction", "reportIncident");
+            request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+            send(request);
+            Assert.fail("Expected a failure response!");
+        } catch (PolicyFailureError failure) {
+            PolicyFailure policyFailure = failure.getFailure();
+            Assert.assertNotNull(policyFailure);
+            Assert.assertEquals(PolicyFailureType.Authorization, policyFailure.getType());
+        }
+
+        userRoles.add("role-2");
+        
+        // Should Succeed
+        request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/multi/resource");
+        request.header("SOAPAction", "reportIncident");
+        request.contextAttribute(SoapAuthorizationPolicy.AUTHENTICATED_USER_ROLES, userRoles);
+        
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+    }
+
+}


### PR DESCRIPTION
Added `SOAP Authorization Policy`.

JIRA: https://issues.jboss.org/browse/APIMAN-931
## 
#### Screenshots

<img width="1192" alt="screen shot 2016-02-15 at 4 53 26 pm" src="https://cloud.githubusercontent.com/assets/3844502/13061292/2202f868-d405-11e5-8a5e-58d7a7484cc0.png">
## 

<img width="1293" alt="screen shot 2016-02-15 at 4 53 18 pm" src="https://cloud.githubusercontent.com/assets/3844502/13061293/2440fe68-d405-11e5-80d6-e63f420b4387.png">
## 

<img width="962" alt="screen shot 2016-02-15 at 4 57 58 pm" src="https://cloud.githubusercontent.com/assets/3844502/13061767/010298aa-d408-11e5-9f19-3e39361be70d.png">
## 

<img width="977" alt="screen shot 2016-02-15 at 8 03 59 pm" src="https://cloud.githubusercontent.com/assets/3844502/13064273/58e0dfc0-d41f-11e5-923b-3adae020a408.png">

cc @EricWittmann 
