### PR TITLE
APIMAN-1012: Policy - URL Whitelist Policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
     <module>test-policy</module>
     <module>transformation-policy</module>
     <module>log-policy</module>
+    <module>url-whitelist-policy</module>
   </modules>
 
   <profiles>

--- a/url-whitelist-policy/README.md
+++ b/url-whitelist-policy/README.md
@@ -1,0 +1,13 @@
+# url-whitelist-policy
+
+A policy that only permits requests matching a whitelist.
+
+The policy allows the user to control which incoming requests are permitted to be passed on to the back-end service. Permission is granted by adding whitelist entries for a URL. Individual HTTP methods can also be allowed or denied per whitelist entry.
+
+## How it works
+
+On receiving a request, the policy normalises the incoming URL, then applies the configured rules using a regular expression against the normalised URL. If both URL and HTTP method are permitted, the request is passed to the back-end API unmodified. If not, an HTTP 401 Unauthorized response is returned and the call to the back-end service is not made.
+
+## Author
+
+Pete Cornish <outofcoffee@gmail.com>

--- a/url-whitelist-policy/pom.xml
+++ b/url-whitelist-policy/pom.xml
@@ -41,6 +41,18 @@
       <artifactId>apiman-gateway-engine-policies</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-test-policies</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/url-whitelist-policy/pom.xml
+++ b/url-whitelist-policy/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apiman.plugins</groupId>
+    <artifactId>apiman-plugins</artifactId>
+    <version>1.2.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>apiman-plugins-url-whitelist-policy</artifactId>
+  <packaging>war</packaging>
+  <name>apiman-plugins-url-whitelist-policy</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+
+    <!-- apiman dependencies (must be excluded from the WAR) -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-beans</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-policies</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webResources>
+            <resource>
+              <directory>src/main/apiman</directory>
+              <targetPath>META-INF/apiman</targetPath>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/url-whitelist-policy/src/main/apiman/plugin.json
+++ b/url-whitelist-policy/src/main/apiman/plugin.json
@@ -1,0 +1,6 @@
+{
+  "frameworkVersion" : 1.0,
+  "name" : "URL Whitelist Policy Plugin",
+  "description" : "This plugin only permits requests matching a whitelist.",
+  "version" : "${project.version}"
+}

--- a/url-whitelist-policy/src/main/apiman/policyDefs/schemas/url-whitelist-policyDef.schema
+++ b/url-whitelist-policy/src/main/apiman/policyDefs/schemas/url-whitelist-policyDef.schema
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title" : "URL Whitelist Policy",
+  "description" : "Add whitelist entries for the the requests that should be permitted.",
+  "properties": {
+    "removePathPrefix": {
+      "type": "boolean",
+      "title": "Remove Path Prefix (e.g. /apiman-gateway/myorg/myapi/1.0)",
+      "default": true
+    },
+    "whitelist": {
+      "title": "Add Whitelist Entries",
+      "type": "array",
+      "format": "table",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "title": "Whitelist Entry",
+        "description": "Permits a request matching criteria.",
+        "properties": {
+          "regex": {
+            "title": "URL Regex (e.g. /foo/[0-9]/bar)",
+            "type": "string"
+          },
+          "methodGet": {
+            "type": "boolean",
+            "title": "GET",
+            "default": false
+          },
+          "methodPost": {
+            "type": "boolean",
+            "title": "POST",
+            "default": false
+          },
+          "methodPut": {
+            "type": "boolean",
+            "title": "PUT",
+            "default": false
+          },
+          "methodPatch": {
+            "type": "boolean",
+            "title": "PATCH",
+            "default": false
+          },
+          "methodDelete": {
+            "type": "boolean",
+            "title": "DELETE",
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/url-whitelist-policy/src/main/apiman/policyDefs/schemas/url-whitelist-policyDef.schema
+++ b/url-whitelist-policy/src/main/apiman/policyDefs/schemas/url-whitelist-policyDef.schema
@@ -47,6 +47,21 @@
             "type": "boolean",
             "title": "DELETE",
             "default": false
+          },
+          "methodHead": {
+            "type": "boolean",
+            "title": "HEAD",
+            "default": false
+          },
+          "methodOptions": {
+            "type": "boolean",
+            "title": "OPTIONS",
+            "default": false
+          },
+          "methodTrace": {
+            "type": "boolean",
+            "title": "TRACE",
+            "default": false
           }
         }
       }

--- a/url-whitelist-policy/src/main/apiman/policyDefs/url-whitelist-policyDef.json
+++ b/url-whitelist-policy/src/main/apiman/policyDefs/url-whitelist-policyDef.json
@@ -1,0 +1,9 @@
+{
+  "id" : "url-whitelist-policy",
+  "name" : "URL Whitelist Policy",
+  "description" : "A policy that only permits requests matching a whitelist.",
+  "policyImpl" : "plugin:${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}/io.apiman.plugins.urlwhitelist.UrlWhitelistPolicy",
+  "icon" : "sliders",
+  "formType" : "JsonSchema",
+  "form" : "schemas/url-whitelist-policyDef.schema"
+}

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
@@ -75,14 +75,13 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
                 path = path.substring(APIMAN_GATEWAY.length());
             }
 
-            // remove org prefix, e.g. /myorg
-            path = path.substring(request.getApiOrgId().length() + 1);
+            // remove org/API/version prefix, e.g. '/myorg/myapi/1.0'
+            final String apiPrefix = String.format("/%s/%s/%s",
+                    request.getApiOrgId(),
+                    request.getApiId(),
+                    request.getApiVersion());
 
-            // remove API prefix, e.g. /myapi
-            path = path.substring(request.getApiId().length() + 1);
-
-            // remove version prefix, e.g. /1.0
-            path = path.substring(request.getApiVersion().length() + 1);
+            path = path.substring(apiPrefix.length());
         }
 
         return path;

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
@@ -1,0 +1,117 @@
+package io.apiman.plugins.urlwhitelist;
+
+import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.plugins.urlwhitelist.beans.UrlWhitelistBean;
+import io.apiman.plugins.urlwhitelist.beans.WhitelistEntryBean;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+/**
+ * A policy that only permits requests matching a whitelist.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
+    private static final String APIMAN_GATEWAY = "/apiman-gateway";
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#getConfigurationClass()
+     */
+    @Override
+    protected Class<UrlWhitelistBean> getConfigurationClass() {
+        return UrlWhitelistBean.class;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#doApply(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    protected void doApply(ApiRequest request, IPolicyContext context, UrlWhitelistBean config,
+                           IPolicyChain<ApiRequest> chain) {
+
+        // normalise, for safety
+        final String normalisedPath;
+        try {
+            normalisedPath = getNormalisedPath(config, request);
+        } catch (Exception e) {
+            chain.throwError(new RuntimeException(String.format(
+                    "Error getting normalised path from: %s", request.getUrl()), e));
+            return;
+        }
+
+        final boolean requestPermitted;
+        try {
+            requestPermitted = isRequestPermitted(config, normalisedPath, request.getType());
+        } catch (Exception e) {
+            chain.throwError(new RuntimeException(String.format(
+                    "Error checking if request is permitted: %s %s", request.getType(), normalisedPath), e));
+            return;
+        }
+
+        if (requestPermitted) {
+            chain.doApply(request);
+        } else {
+            chain.doFailure(new PolicyFailure(PolicyFailureType.Authorization,
+                    HttpURLConnection.HTTP_UNAUTHORIZED,
+                    String.format("Normalised URL '%s' not permitted.", normalisedPath)));
+        }
+    }
+
+    private String getNormalisedPath(UrlWhitelistBean config, ApiRequest request) throws URISyntaxException {
+        // normalise, for safety
+        final URI normalisedUrl = new URI(request.getUrl()).normalize();
+
+        String path = normalisedUrl.getPath();
+        if (config.isRemovePathPrefix()) {
+            if (path.startsWith(APIMAN_GATEWAY)) {
+                path = path.substring(APIMAN_GATEWAY.length());
+            }
+
+            // remove org prefix, e.g. /myorg
+            path = path.substring(request.getApiOrgId().length() + 1);
+
+            // remove API prefix, e.g. /myapi
+            path = path.substring(request.getApiId().length() + 1);
+
+            // remove version prefix, e.g. /1.0
+            path = path.substring(request.getApiVersion().length() + 1);
+        }
+
+        return path;
+    }
+
+    private boolean isRequestPermitted(UrlWhitelistBean config, String normalisedUrl, String method) {
+        for (WhitelistEntryBean whitelistEntry : config.getWhitelist()) {
+            if (Pattern.compile(whitelistEntry.getRegex()).matcher(normalisedUrl).matches()) {
+                return isMethodPermitted(whitelistEntry, method);
+            }
+        }
+        return false;
+    }
+
+    private boolean isMethodPermitted(WhitelistEntryBean whitelistEntry, String method) {
+        switch (method.toUpperCase()) {
+            case "GET":
+                return whitelistEntry.isMethodGet();
+            case "POST":
+                return whitelistEntry.isMethodPost();
+            case "PUT":
+                return whitelistEntry.isMethodPut();
+            case "PATCH":
+                return whitelistEntry.isMethodPatch();
+            case "DELETE":
+                return whitelistEntry.isMethodDelete();
+
+            default:
+                throw new UnsupportedOperationException(String.format("Method '%s' is not supported", method));
+        }
+    }
+}

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/UrlWhitelistBean.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/UrlWhitelistBean.java
@@ -28,7 +28,9 @@ public class UrlWhitelistBean implements Serializable {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(whitelist).append(removePathPrefix)
+        return new HashCodeBuilder()
+                .append(whitelist)
+                .append(removePathPrefix)
                 .toHashCode();
     }
 
@@ -40,8 +42,11 @@ public class UrlWhitelistBean implements Serializable {
         if (!(other instanceof UrlWhitelistBean)) {
             return false;
         }
-        UrlWhitelistBean rhs = ((UrlWhitelistBean) other);
-        return new EqualsBuilder().append(whitelist, rhs.whitelist).append(removePathPrefix, rhs.removePathPrefix).isEquals();
+        final UrlWhitelistBean rhs = ((UrlWhitelistBean) other);
+        return new EqualsBuilder()
+                .append(whitelist, rhs.whitelist)
+                .append(removePathPrefix, rhs.removePathPrefix)
+                .isEquals();
     }
 
     public Set<WhitelistEntryBean> getWhitelist() {

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/UrlWhitelistBean.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/UrlWhitelistBean.java
@@ -1,0 +1,62 @@
+package io.apiman.plugins.urlwhitelist.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Configuration for the URL Whitelist Policy.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonPropertyOrder({"removePathPrefix", "whitelist"})
+public class UrlWhitelistBean implements Serializable {
+    @JsonProperty("whitelist")
+    @JsonDeserialize(as = java.util.LinkedHashSet.class)
+    private Set<WhitelistEntryBean> whitelist = new LinkedHashSet<>();
+
+    @JsonProperty("removePathPrefix")
+    private boolean removePathPrefix = true;
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(whitelist).append(removePathPrefix)
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof UrlWhitelistBean)) {
+            return false;
+        }
+        UrlWhitelistBean rhs = ((UrlWhitelistBean) other);
+        return new EqualsBuilder().append(whitelist, rhs.whitelist).append(removePathPrefix, rhs.removePathPrefix).isEquals();
+    }
+
+    public Set<WhitelistEntryBean> getWhitelist() {
+        return whitelist;
+    }
+
+    public void setWhitelist(Set<WhitelistEntryBean> whitelist) {
+        this.whitelist = whitelist;
+    }
+
+    public boolean isRemovePathPrefix() {
+        return removePathPrefix;
+    }
+
+    public void setRemovePathPrefix(boolean removePathPrefix) {
+        this.removePathPrefix = removePathPrefix;
+    }
+}

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/WhitelistEntryBean.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/WhitelistEntryBean.java
@@ -7,10 +7,12 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
+ * Whitelist entry configuration bean.
+ *
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
-@JsonPropertyOrder({"regex", "methodGet", "methodPost", "methodPut", "methodPatch", "methodDelete"})
+@JsonPropertyOrder({"regex", "methodGet", "methodPost", "methodPut", "methodPatch", "methodDelete", "methodHead", "methodOptions", "methodTrace"})
 public class WhitelistEntryBean {
     @JsonProperty("regex")
     private String regex;
@@ -30,9 +32,27 @@ public class WhitelistEntryBean {
     @JsonProperty("methodDelete")
     private boolean methodDelete = false;
 
+    @JsonProperty("methodHead")
+    private boolean methodHead = false;
+
+    @JsonProperty("methodOptions")
+    private boolean methodOptions = false;
+
+    @JsonProperty("methodTrace")
+    private boolean methodTrace = false;
+
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(regex).append(methodGet).append(methodPost).append(methodDelete)
+        return new HashCodeBuilder()
+                .append(regex)
+                .append(methodGet)
+                .append(methodPost)
+                .append(methodPut)
+                .append(methodPatch)
+                .append(methodDelete)
+                .append(methodHead)
+                .append(methodOptions)
+                .append(methodTrace)
                 .toHashCode();
     }
 
@@ -44,9 +64,18 @@ public class WhitelistEntryBean {
         if (!(other instanceof WhitelistEntryBean)) {
             return false;
         }
-        WhitelistEntryBean rhs = ((WhitelistEntryBean) other);
-        return new EqualsBuilder().append(regex, rhs.regex).append(methodGet, rhs.methodGet)
-                .append(methodPost, rhs.methodPost).append(methodDelete, rhs.methodDelete).isEquals();
+        final WhitelistEntryBean rhs = ((WhitelistEntryBean) other);
+        return new EqualsBuilder()
+                .append(regex, rhs.regex)
+                .append(methodGet, rhs.methodGet)
+                .append(methodPost, rhs.methodPost)
+                .append(methodPut, rhs.methodPut)
+                .append(methodPatch, rhs.methodPatch)
+                .append(methodDelete, rhs.methodDelete)
+                .append(methodHead, rhs.methodHead)
+                .append(methodOptions, rhs.methodOptions)
+                .append(methodTrace, rhs.methodTrace)
+                .isEquals();
     }
 
     public String getRegex() {
@@ -95,5 +124,29 @@ public class WhitelistEntryBean {
 
     public void setMethodDelete(boolean methodDelete) {
         this.methodDelete = methodDelete;
+    }
+
+    public boolean isMethodOptions() {
+        return methodOptions;
+    }
+
+    public void setMethodOptions(boolean methodOptions) {
+        this.methodOptions = methodOptions;
+    }
+
+    public boolean isMethodTrace() {
+        return methodTrace;
+    }
+
+    public void setMethodTrace(boolean methodTrace) {
+        this.methodTrace = methodTrace;
+    }
+
+    public boolean isMethodHead() {
+        return methodHead;
+    }
+
+    public void setMethodHead(boolean methodHead) {
+        this.methodHead = methodHead;
     }
 }

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/WhitelistEntryBean.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/beans/WhitelistEntryBean.java
@@ -1,0 +1,99 @@
+package io.apiman.plugins.urlwhitelist.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+/**
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonPropertyOrder({"regex", "methodGet", "methodPost", "methodPut", "methodPatch", "methodDelete"})
+public class WhitelistEntryBean {
+    @JsonProperty("regex")
+    private String regex;
+
+    @JsonProperty("methodGet")
+    private boolean methodGet = false;
+
+    @JsonProperty("methodPost")
+    private boolean methodPost = false;
+
+    @JsonProperty("methodPut")
+    private boolean methodPut = false;
+
+    @JsonProperty("methodPatch")
+    private boolean methodPatch = false;
+
+    @JsonProperty("methodDelete")
+    private boolean methodDelete = false;
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(regex).append(methodGet).append(methodPost).append(methodDelete)
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof WhitelistEntryBean)) {
+            return false;
+        }
+        WhitelistEntryBean rhs = ((WhitelistEntryBean) other);
+        return new EqualsBuilder().append(regex, rhs.regex).append(methodGet, rhs.methodGet)
+                .append(methodPost, rhs.methodPost).append(methodDelete, rhs.methodDelete).isEquals();
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public boolean isMethodGet() {
+        return methodGet;
+    }
+
+    public void setMethodGet(boolean methodGet) {
+        this.methodGet = methodGet;
+    }
+
+    public boolean isMethodPost() {
+        return methodPost;
+    }
+
+    public void setMethodPost(boolean methodPost) {
+        this.methodPost = methodPost;
+    }
+
+    public boolean isMethodPut() {
+        return methodPut;
+    }
+
+    public void setMethodPut(boolean methodPut) {
+        this.methodPut = methodPut;
+    }
+
+    public boolean isMethodPatch() {
+        return methodPatch;
+    }
+
+    public void setMethodPatch(boolean methodPatch) {
+        this.methodPatch = methodPatch;
+    }
+
+    public boolean isMethodDelete() {
+        return methodDelete;
+    }
+
+    public void setMethodDelete(boolean methodDelete) {
+        this.methodDelete = methodDelete;
+    }
+}

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/util/Messages.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/util/Messages.java
@@ -1,0 +1,59 @@
+package io.apiman.plugins.urlwhitelist.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * Formats messages from a ResourceBundle.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class Messages {
+    private static final String DEFAULT_BUNDLE_NAME = "messages";
+
+    private final ResourceBundle resourceBundle;
+    private final String messagePrefix;
+
+    public Messages(String bundleName, String messagePrefix) {
+        this.messagePrefix = (StringUtils.isNotBlank(messagePrefix) ? messagePrefix + "." : "");
+        this.resourceBundle = ResourceBundle.getBundle(bundleName);
+    }
+
+    /**
+     * Creates a new {@link Messages} using the package name of the class as the path and the simple name of the
+     * class as the message prefix.
+     *
+     * @param clazz the Class for which to get the message bundle
+     */
+    public Messages(Class<?> clazz) {
+        this(clazz.getPackage().getName() + "." + DEFAULT_BUNDLE_NAME, clazz.getSimpleName());
+    }
+
+    /**
+     * Creates a new {@link Messages} using the package name of the class as the path and the simple name of the
+     * class as the message prefix.
+     *
+     * @param clazz the Class for which to get the message bundle
+     * @return a new message bundle
+     */
+    public static Messages getMessageBundle(Class<?> clazz) {
+        return new Messages(clazz);
+    }
+
+    /**
+     * Return the message <code>key</code> formatted with the given <code>params</code>.
+     *
+     * @param key    the message key in the ResourceBundle
+     * @param params the format arguments
+     * @return the formatted String
+     */
+    public String format(String key, Object... params) {
+        try {
+            return String.format(resourceBundle.getString(messagePrefix + key), params);
+        } catch (MissingResourceException e) {
+            return '!' + key + '!';
+        }
+    }
+}

--- a/url-whitelist-policy/src/main/resources/io/apiman/plugins/urlwhitelist/messages.properties
+++ b/url-whitelist-policy/src/main/resources/io/apiman/plugins/urlwhitelist/messages.properties
@@ -1,0 +1,5 @@
+UrlWhitelistPolicy.Error.CompilingPattern=Error compiling whitelist regex pattern: %s
+UrlWhitelistPolicy.Error.NormalisingPath=Error getting normalised path from: %s
+UrlWhitelistPolicy.Error.CheckingRequest=Error checking if request is permitted: %s %s
+UrlWhitelistPolicy.Failure.UrlNotPermitted=Normalised URL '%s' not permitted.
+UrlWhitelistPolicy.Error.MethodNotSupported=Method '%s' is not supported

--- a/url-whitelist-policy/src/test/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicyTest.java
+++ b/url-whitelist-policy/src/test/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicyTest.java
@@ -1,36 +1,49 @@
 package io.apiman.plugins.urlwhitelist;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apiman.gateway.engine.beans.PolicyFailure;
 import io.apiman.gateway.engine.beans.PolicyFailureType;
 import io.apiman.test.policies.*;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+/**
+ * Policy tests for {@link UrlWhitelistPolicy} plugin.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
 @SuppressWarnings("nls")
 @TestingPolicy(UrlWhitelistPolicy.class)
 public class UrlWhitelistPolicyTest extends ApimanPolicyTest {
+    private static final String API_BASE_URL = "/PolicyTester/TestApi/1";
+    private static ObjectMapper jsonMapper;
 
-    @Test
-    @Configuration(classpathConfigFile = "basic-config.json")
-    @BackEndApi(EchoBackEndApi.class)
-    public void testPermitted() throws Throwable {
-        final PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/PolicyTester/TestApi/1/allow/example");
-        final PolicyTestResponse response = send(request);
-
-        assertEquals(HttpURLConnection.HTTP_OK, response.code());
-        assertNotNull(response.body());
+    /**
+     * Shared test initialisation.
+     */
+    @BeforeClass
+    public static void setUp() {
+        jsonMapper = new ObjectMapper();
     }
 
-    @Test
-    @Configuration(classpathConfigFile = "basic-config.json")
-    @BackEndApi(EchoBackEndApi.class)
-    public void testDenied() throws Throwable {
-        final PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/PolicyTester/TestApi/1/deny/example");
+    /**
+     * Makes a request with the given {@code method} to the specified {@code resource}, expecting an
+     * HTTP 401 Unauthorized response.
+     *
+     * @param method   the HTTP method
+     * @param resource the resource to request
+     * @throws Throwable
+     */
+    private void requestExpectPolicyFailure(PolicyTestRequestType method, String resource) throws Throwable {
+        final PolicyTestRequest request = PolicyTestRequest.build(method, resource);
 
         try {
             send(request);
@@ -42,5 +55,140 @@ public class UrlWhitelistPolicyTest extends ApimanPolicyTest {
             assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, failure.getFailureCode());
             assertEquals(PolicyFailureType.Authorization, failure.getType());
         }
+    }
+
+    /**
+     * Makes a request with the given {@code method} to the specified {@code resource}, expecting an
+     * HTTP 200 OK response from the {@link EchoBackEndApi}.
+     *
+     * @param method   the HTTP method
+     * @param resource the resource to request
+     * @throws Throwable
+     */
+    private void requestExpectPolicySuccess(PolicyTestRequestType method, String resource) throws Throwable {
+        final PolicyTestRequest request = PolicyTestRequest.build(method, resource);
+        final PolicyTestResponse response = send(request);
+
+        assertEquals(HttpURLConnection.HTTP_OK, response.code());
+        assertNotNull(response.body());
+
+        // the requested URL is mirrored back by the EchoBackEndApi in its response body
+        final Map responseAsMap = jsonMapper.readValue(response.body(), HashMap.class);
+        assertEquals(resource, responseAsMap.get("resource"));
+    }
+
+    /**
+     * Expects that a request meeting both URL and HTTP method rules is permitted to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testAllowedUrlAndMethod() throws Throwable {
+        requestExpectPolicySuccess(PolicyTestRequestType.GET, API_BASE_URL + "/allow/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.POST, API_BASE_URL + "/allow/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.PUT, API_BASE_URL + "/allow/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.DELETE, API_BASE_URL + "/allow/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.HEAD, API_BASE_URL + "/allow/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.OPTIONS, API_BASE_URL + "/allow/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.TRACE, API_BASE_URL + "/allow/example");
+    }
+
+    /**
+     * Expects that a request whose URL is normalised to match an allowed URL rule is permitted
+     * to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testUrlNormalisationAllowed() throws Throwable {
+        requestExpectPolicySuccess(PolicyTestRequestType.GET, API_BASE_URL + "/../../TestApi/1/allow/example");
+    }
+
+    /**
+     * Expects that a request whose URL is normalised to match an disallowed URL rule is not permitted
+     * to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testUrlNormalisationDenied() throws Throwable {
+        requestExpectPolicyFailure(PolicyTestRequestType.GET, API_BASE_URL + "/../../TestApi/1/deny/example");
+    }
+
+    /**
+     * Expects that a request not meeting the URL rules is not permitted to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testDeniedUrl() throws Throwable {
+        requestExpectPolicyFailure(PolicyTestRequestType.GET, API_BASE_URL + "/deny/example");
+    }
+
+    /**
+     * Expects that a request not meeting the HTTP method rules is not permitted to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testDeniedMethod() throws Throwable {
+        // methods are disallowed
+        requestExpectPolicyFailure(PolicyTestRequestType.GET, API_BASE_URL + "/mixed/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.POST, API_BASE_URL + "/mixed/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.PUT, API_BASE_URL + "/mixed/example");
+
+        // same URL as above, but method permitted
+        requestExpectPolicySuccess(PolicyTestRequestType.DELETE, API_BASE_URL + "/mixed/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.HEAD, API_BASE_URL + "/mixed/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.OPTIONS, API_BASE_URL + "/mixed/example");
+        requestExpectPolicySuccess(PolicyTestRequestType.TRACE, API_BASE_URL + "/mixed/example");
+    }
+
+    /**
+     * Expects that, by default, if a whitelist entry does not exist for a URL, the request is not permitted
+     * to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testDefaultDenyMissingWhitelist() throws Throwable {
+        requestExpectPolicyFailure(PolicyTestRequestType.GET, API_BASE_URL + "/unconfigured/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.POST, API_BASE_URL + "/unconfigured/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.PUT, API_BASE_URL + "/unconfigured/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.DELETE, API_BASE_URL + "/unconfigured/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.HEAD, API_BASE_URL + "/unconfigured/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.OPTIONS, API_BASE_URL + "/unconfigured/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.TRACE, API_BASE_URL + "/unconfigured/example");
+    }
+
+    /**
+     * Expects that, by default, if a whitelist entry exists for a URL, but is missing method configurations,
+     * the request is not permitted to continue to the back-end service.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testDefaultDenyPartiallyConfiguredWhitelist() throws Throwable {
+        requestExpectPolicyFailure(PolicyTestRequestType.GET, API_BASE_URL + "/partial/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.POST, API_BASE_URL + "/partial/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.PUT, API_BASE_URL + "/partial/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.DELETE, API_BASE_URL + "/partial/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.HEAD, API_BASE_URL + "/partial/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.OPTIONS, API_BASE_URL + "/partial/example");
+        requestExpectPolicyFailure(PolicyTestRequestType.TRACE, API_BASE_URL + "/partial/example");
     }
 }

--- a/url-whitelist-policy/src/test/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicyTest.java
+++ b/url-whitelist-policy/src/test/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicyTest.java
@@ -1,0 +1,46 @@
+package io.apiman.plugins.urlwhitelist;
+
+import io.apiman.gateway.engine.beans.PolicyFailure;
+import io.apiman.gateway.engine.beans.PolicyFailureType;
+import io.apiman.test.policies.*;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@SuppressWarnings("nls")
+@TestingPolicy(UrlWhitelistPolicy.class)
+public class UrlWhitelistPolicyTest extends ApimanPolicyTest {
+
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testPermitted() throws Throwable {
+        final PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/PolicyTester/TestApi/1/allow/example");
+        final PolicyTestResponse response = send(request);
+
+        assertEquals(HttpURLConnection.HTTP_OK, response.code());
+        assertNotNull(response.body());
+    }
+
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testDenied() throws Throwable {
+        final PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/PolicyTester/TestApi/1/deny/example");
+
+        try {
+            send(request);
+            fail(PolicyFailureError.class + " expected");
+
+        } catch (PolicyFailureError policyFailureError) {
+            final PolicyFailure failure = policyFailureError.getFailure();
+
+            assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, failure.getFailureCode());
+            assertEquals(PolicyFailureType.Authorization, failure.getType());
+        }
+    }
+}

--- a/url-whitelist-policy/src/test/resources/basic-config.json
+++ b/url-whitelist-policy/src/test/resources/basic-config.json
@@ -7,7 +7,10 @@
       "methodPost": true,
       "methodPut": true,
       "methodPatch": true,
-      "methodDelete": true
+      "methodDelete": true,
+      "methodHead": true,
+      "methodOptions": true,
+      "methodTrace": true
     },
     {
       "regex": "/deny/.*",
@@ -15,7 +18,24 @@
       "methodPost": false,
       "methodPut": false,
       "methodPatch": false,
-      "methodDelete": false
+      "methodDelete": false,
+      "methodHead": false,
+      "methodOptions": false,
+      "methodTrace": false
+    },
+    {
+      "regex": "/mixed/.*",
+      "methodGet": false,
+      "methodPost": false,
+      "methodPut": false,
+      "methodPatch": false,
+      "methodDelete": true,
+      "methodHead": true,
+      "methodOptions": true,
+      "methodTrace": true
+    },
+    {
+      "regex": "/partial/.*"
     }
   ]
 }

--- a/url-whitelist-policy/src/test/resources/basic-config.json
+++ b/url-whitelist-policy/src/test/resources/basic-config.json
@@ -1,0 +1,21 @@
+{
+  "removePathPrefix": true,
+  "whitelist": [
+    {
+      "regex": "/allow/.*",
+      "methodGet": true,
+      "methodPost": true,
+      "methodPut": true,
+      "methodPatch": true,
+      "methodDelete": true
+    },
+    {
+      "regex": "/deny/.*",
+      "methodGet": false,
+      "methodPost": false,
+      "methodPut": false,
+      "methodPatch": false,
+      "methodDelete": false
+    }
+  ]
+}


### PR DESCRIPTION
# url-whitelist-policy

A policy that only permits requests matching a whitelist. See https://issues.jboss.org/browse/APIMAN-1012

The policy allows the user to control which incoming requests are permitted to be passed on to the back-end service. Permission is granted by adding whitelist entries for a URL. Individual HTTP methods can also be allowed or denied per whitelist entry.
## How it works

On receiving a request, the policy normalises the incoming URL, then applies the configured rules using a regular expression against the normalised URL. If both URL and HTTP method are permitted, the request is passed to the back-end API unmodified. If not, an HTTP 401 Unauthorized response is returned and the call to the back-end service is not made.
