### PR TITLE
Bugfixes and improvements for URL Whitelist policy

### DIFF
--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
@@ -24,7 +24,12 @@ import java.util.regex.Pattern;
  */
 public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
     private static final String APIMAN_GATEWAY = "/apiman-gateway";
-    private static final Messages MESSAGES = Messages.getMessageBundle(UrlWhitelistPolicy.class);
+
+    private final Messages messages;
+
+    public UrlWhitelistPolicy() {
+        messages = Messages.getMessageBundle(UrlWhitelistPolicy.class);
+    }
 
     /**
      * Cache of precompiled URL patterns. Note that {@link Pattern} is thread-safe.
@@ -52,7 +57,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
             try {
                 patternMap.put(whitelistEntry.getRegex(), Pattern.compile(whitelistEntry.getRegex()));
             } catch (Exception e) {
-                throw new ConfigurationParseException(MESSAGES.format("Error.CompilingPattern", whitelistEntry.getRegex()), e);
+                throw new ConfigurationParseException(messages.format("Error.CompilingPattern", whitelistEntry.getRegex()), e);
             }
         }
 
@@ -71,7 +76,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
         try {
             normalisedPath = getNormalisedPath(config, request);
         } catch (Exception e) {
-            chain.throwError(new RuntimeException(MESSAGES.format("Error.NormalisingPath", request.getUrl()), e));
+            chain.throwError(new RuntimeException(messages.format("Error.NormalisingPath", request.getUrl()), e));
             return;
         }
 
@@ -79,7 +84,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
         try {
             requestPermitted = isRequestPermitted(config, normalisedPath, request.getType());
         } catch (Exception e) {
-            chain.throwError(new RuntimeException(MESSAGES.format(
+            chain.throwError(new RuntimeException(messages.format(
                     "Error.CheckingRequest", request.getType(), normalisedPath), e));
             return;
         }
@@ -88,7 +93,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
             chain.doApply(request);
         } else {
             chain.doFailure(new PolicyFailure(PolicyFailureType.Authorization,
-                    HttpURLConnection.HTTP_UNAUTHORIZED, MESSAGES.format("Failure.UrlNotPermitted", normalisedPath)));
+                    HttpURLConnection.HTTP_UNAUTHORIZED, messages.format("Failure.UrlNotPermitted", normalisedPath)));
         }
     }
 
@@ -169,7 +174,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
                 return whitelistEntry.isMethodTrace();
 
             default:
-                throw new UnsupportedOperationException(MESSAGES.format("Error.MethodNotSupported", method));
+                throw new UnsupportedOperationException(messages.format("Error.MethodNotSupported", method));
         }
     }
 }

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
@@ -23,13 +23,8 @@ import java.util.regex.Pattern;
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
+    private static final Messages MESSAGES = new Messages("io.apiman.plugins.urlwhitelist", "UrlWhitelistPolicy");
     private static final String APIMAN_GATEWAY = "/apiman-gateway";
-
-    private final Messages messages;
-
-    public UrlWhitelistPolicy() {
-        messages = Messages.getMessageBundle(UrlWhitelistPolicy.class);
-    }
 
     /**
      * Cache of precompiled URL patterns. Note that {@link Pattern} is thread-safe.
@@ -57,7 +52,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
             try {
                 patternMap.put(whitelistEntry.getRegex(), Pattern.compile(whitelistEntry.getRegex()));
             } catch (Exception e) {
-                throw new ConfigurationParseException(messages.format("Error.CompilingPattern", whitelistEntry.getRegex()), e);
+                throw new ConfigurationParseException(MESSAGES.format("Error.CompilingPattern", whitelistEntry.getRegex()), e);
             }
         }
 
@@ -76,7 +71,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
         try {
             normalisedPath = getNormalisedPath(config, request);
         } catch (Exception e) {
-            chain.throwError(new RuntimeException(messages.format("Error.NormalisingPath", request.getUrl()), e));
+            chain.throwError(new RuntimeException(MESSAGES.format("Error.NormalisingPath", request.getUrl()), e));
             return;
         }
 
@@ -84,7 +79,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
         try {
             requestPermitted = isRequestPermitted(config, normalisedPath, request.getType());
         } catch (Exception e) {
-            chain.throwError(new RuntimeException(messages.format(
+            chain.throwError(new RuntimeException(MESSAGES.format(
                     "Error.CheckingRequest", request.getType(), normalisedPath), e));
             return;
         }
@@ -93,7 +88,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
             chain.doApply(request);
         } else {
             chain.doFailure(new PolicyFailure(PolicyFailureType.Authorization,
-                    HttpURLConnection.HTTP_UNAUTHORIZED, messages.format("Failure.UrlNotPermitted", normalisedPath)));
+                    HttpURLConnection.HTTP_FORBIDDEN, MESSAGES.format("Failure.UrlNotPermitted", normalisedPath)));
         }
     }
 
@@ -174,7 +169,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
                 return whitelistEntry.isMethodTrace();
 
             default:
-                throw new UnsupportedOperationException(messages.format("Error.MethodNotSupported", method));
+                throw new UnsupportedOperationException(MESSAGES.format("Error.MethodNotSupported", method));
         }
     }
 }

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
@@ -14,7 +14,8 @@ import io.apiman.plugins.urlwhitelist.util.Messages;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -29,7 +30,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
     /**
      * Cache of precompiled URL patterns. Note that {@link Pattern} is thread-safe.
      */
-    private HashMap<String, Pattern> patternMap;
+    private static final Map<String, Pattern> PATTERN_MAP = new ConcurrentHashMap<>();
 
     /**
      * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#getConfigurationClass()
@@ -47,10 +48,9 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
         final UrlWhitelistBean config = super.parseConfiguration(jsonConfiguration);
 
         // precompile patterns for performance
-        patternMap = new HashMap<>();
         for (WhitelistEntryBean whitelistEntry : config.getWhitelist()) {
             try {
-                patternMap.put(whitelistEntry.getRegex(), Pattern.compile(whitelistEntry.getRegex()));
+                PATTERN_MAP.put(whitelistEntry.getRegex(), Pattern.compile(whitelistEntry.getRegex()));
             } catch (Exception e) {
                 throw new ConfigurationParseException(MESSAGES.format("Error.CompilingPattern", whitelistEntry.getRegex()), e);
             }
@@ -134,7 +134,7 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
      */
     private boolean isRequestPermitted(UrlWhitelistBean config, String normalisedPath, String method) {
         for (WhitelistEntryBean whitelistEntry : config.getWhitelist()) {
-            final Pattern pattern = patternMap.get(whitelistEntry.getRegex());
+            final Pattern pattern = PATTERN_MAP.get(whitelistEntry.getRegex());
             if (null != pattern && pattern.matcher(normalisedPath).matches()) {
                 return isMethodPermitted(whitelistEntry, method);
             }

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicy.java
@@ -134,7 +134,8 @@ public class UrlWhitelistPolicy extends AbstractMappedPolicy<UrlWhitelistBean> {
      */
     private boolean isRequestPermitted(UrlWhitelistBean config, String normalisedPath, String method) {
         for (WhitelistEntryBean whitelistEntry : config.getWhitelist()) {
-            if (patternMap.get(whitelistEntry.getRegex()).matcher(normalisedPath).matches()) {
+            final Pattern pattern = patternMap.get(whitelistEntry.getRegex());
+            if (null != pattern && pattern.matcher(normalisedPath).matches()) {
                 return isMethodPermitted(whitelistEntry, method);
             }
         }

--- a/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/util/Messages.java
+++ b/url-whitelist-policy/src/main/java/io/apiman/plugins/urlwhitelist/util/Messages.java
@@ -16,30 +16,16 @@ public class Messages {
     private final ResourceBundle resourceBundle;
     private final String messagePrefix;
 
-    public Messages(String bundleName, String messagePrefix) {
+    /**
+     * Creates a new {@link Messages} using the package name of the class as the path and the simple name of the
+     * class as the message prefix.
+     *
+     * @param packageName the package name of the bundle
+     * @param messagePrefix the message prefix (can be {@code null})
+     */
+    public Messages(String packageName, String messagePrefix) {
         this.messagePrefix = (StringUtils.isNotBlank(messagePrefix) ? messagePrefix + "." : "");
-        this.resourceBundle = ResourceBundle.getBundle(bundleName);
-    }
-
-    /**
-     * Creates a new {@link Messages} using the package name of the class as the path and the simple name of the
-     * class as the message prefix.
-     *
-     * @param clazz the Class for which to get the message bundle
-     */
-    public Messages(Class<?> clazz) {
-        this(clazz.getPackage().getName() + "." + DEFAULT_BUNDLE_NAME, clazz.getSimpleName());
-    }
-
-    /**
-     * Creates a new {@link Messages} using the package name of the class as the path and the simple name of the
-     * class as the message prefix.
-     *
-     * @param clazz the Class for which to get the message bundle
-     * @return a new message bundle
-     */
-    public static Messages getMessageBundle(Class<?> clazz) {
-        return new Messages(clazz);
+        this.resourceBundle = ResourceBundle.getBundle(packageName + "." + DEFAULT_BUNDLE_NAME);
     }
 
     /**

--- a/url-whitelist-policy/src/test/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicyTest.java
+++ b/url-whitelist-policy/src/test/java/io/apiman/plugins/urlwhitelist/UrlWhitelistPolicyTest.java
@@ -52,7 +52,7 @@ public class UrlWhitelistPolicyTest extends ApimanPolicyTest {
         } catch (PolicyFailureError policyFailureError) {
             final PolicyFailure failure = policyFailureError.getFailure();
 
-            assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, failure.getFailureCode());
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, failure.getFailureCode());
             assertEquals(PolicyFailureType.Authorization, failure.getType());
         }
     }


### PR DESCRIPTION
### Improvements
- Sets policy failure code to 403 Forbidden.
### Fixes
- Fixes message bundle initialisation on Tomcat (due to different classloader behaviour).
- Guards against NPE in URL matcher.
