### PR TITLE
re #1103 Remove pathPattern from SoapAuthorizationPolicy and SoapAuthorizationRule

### DIFF
--- a/soap-authorization-policy/src/main/apiman/policyDefs/schemas/soap-authorization-PolicyDef.schema
+++ b/soap-authorization-policy/src/main/apiman/policyDefs/schemas/soap-authorization-PolicyDef.schema
@@ -8,17 +8,13 @@
   "properties": {
     "rules": {
       "title": "Add Authorization Rule",
-      "description": "Manage the list of fine-grained authorization rules in the box below. If you want a single required role to protect your entire API, simply add one item with a path of \".*\" and an action of \"*\".",
+      "description": "Manage the list of fine-grained authorization rules in the box below. If you want a single required role to protect your entire API, simply add one item with an action of \"*\".",
       "type": "array",
       "format": "table",
       "items": {
         "type": "object",
         "title": "Rule",
         "properties": {
-          "pathPattern": {
-            "title": "Path",
-            "type": "string"
-          },
           "action": {
             "title": "SOAPAction",
             "type": "string"

--- a/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationRule.java
+++ b/soap-authorization-policy/src/main/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationRule.java
@@ -24,7 +24,6 @@ package io.apiman.plugins.soap_authorization_policy;
 public class SoapAuthorizationRule {
 
     private String action;
-    private String pathPattern;
     private String role;
 
     public SoapAuthorizationRule() {
@@ -42,20 +41,6 @@ public class SoapAuthorizationRule {
      */
     public void setAction(String action) {
         this.action = action;
-    }
-
-    /**
-     * @return pathPattern
-     */
-    public String getPathPattern() {
-        return pathPattern;
-    }
-
-    /**
-     * @param pathPattern
-     */
-    public void setPathPattern(String pathPattern) {
-        this.pathPattern = pathPattern;
     }
 
     /**
@@ -78,8 +63,7 @@ public class SoapAuthorizationRule {
     @Override
     public boolean equals(Object obj) {
         SoapAuthorizationRule rule2 = (SoapAuthorizationRule) obj;
-        return this.getAction().equals(rule2.getAction()) && this.getPathPattern().equals(rule2.getPathPattern())
-                && this.getRole().equals(rule2.getRole());
+        return this.getAction().equals(rule2.getAction()) && this.getRole().equals(rule2.getRole());
     }
 
 }

--- a/soap-authorization-policy/src/test/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicyConfigTest.java
+++ b/soap-authorization-policy/src/test/java/io/apiman/plugins/soap_authorization_policy/SoapAuthorizationPolicyConfigTest.java
@@ -18,10 +18,7 @@ package io.apiman.plugins.soap_authorization_policy;
 import io.apiman.gateway.engine.policies.config.MultipleMatchType;
 import io.apiman.gateway.engine.policies.config.UnmatchedRequestType;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,73 +49,6 @@ public class SoapAuthorizationPolicyConfigTest {
        
         Assert.assertNotNull(parsedConfig.getRules());
         Assert.assertTrue(parsedConfig.getRules().isEmpty());
-    }
-    
-    
-    @Test
-    public void testSinglePath() {
-        SoapAuthorizationPolicy policy = new SoapAuthorizationPolicy();
-
-        String config = "{}";
-        Object parsed = policy.parseConfiguration(config);
-        SoapAuthorizationConfig parsedConfig = (SoapAuthorizationConfig) parsed;
-        
-        config = "{\r\n" +
-                "  \"rules\" : [\r\n" +
-                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \".*\", \"role\" : \"role-1\" }\r\n" +
-                "  ]\r\n" +
-                "}";
-        parsed = policy.parseConfiguration(config);
-        parsedConfig = (SoapAuthorizationConfig) parsed;
-        Assert.assertNotNull(parsedConfig.getRules());
-        
-        SoapAuthorizationRule rule1 = new SoapAuthorizationRule();
-        rule1.setAction("reportIncident");
-        rule1.setPathPattern(".*");
-        rule1.setRole("role-1");
-        List<SoapAuthorizationRule> expectedConfiguration = Arrays.asList(rule1);
-        Assert.assertEquals(expectedConfiguration, parsedConfig.getRules());
-    }
-    
-    
-    @Test
-    public void testMultiplePaths() {
-        SoapAuthorizationPolicy policy = new SoapAuthorizationPolicy();
-
-        String config = "{}";
-        Object parsed = policy.parseConfiguration(config);
-        SoapAuthorizationConfig parsedConfig = (SoapAuthorizationConfig) parsed;
-        
-        config = "{\r\n" +
-                "  \"rules\" : [\r\n" +
-                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \".*\", \"role\" : \"role-1\" },\r\n" +
-                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \".+\", \"role\" : \"role-2\" },\r\n" +
-                "    { \"action\" : \"reportIncident\", \"pathPattern\" : \"(.*)\", \"role\" : \"role-3\" }\r\n" +
-                "  ]\r\n" +
-                "}";
-        parsed = policy.parseConfiguration(config);
-        parsedConfig = (SoapAuthorizationConfig) parsed;
-        Assert.assertNotNull(parsedConfig.getRules());
-        
-        SoapAuthorizationRule rule1 = new SoapAuthorizationRule();
-        rule1.setAction("reportIncident");
-        rule1.setPathPattern(".*");
-        rule1.setRole("role-1");
-        List<SoapAuthorizationRule> expectedConfiguration = Arrays.asList(rule1);
-        
-        expectedConfiguration = new ArrayList<>();
-        SoapAuthorizationRule rule2 = new SoapAuthorizationRule();
-        rule2.setAction("reportIncident");
-        rule2.setPathPattern(".+");
-        rule2.setRole("role-2");
-        SoapAuthorizationRule rule3 = new SoapAuthorizationRule();
-        rule3.setAction("reportIncident");
-        rule3.setPathPattern("(.*)");
-        rule3.setRole("role-3");
-        expectedConfiguration.add(rule1);
-        expectedConfiguration.add(rule2);
-        expectedConfiguration.add(rule3);
-        Assert.assertEquals(expectedConfiguration, parsedConfig.getRules());
     }
     
     


### PR DESCRIPTION
**Changes:**
- Updated `SoapAuthorizationPolicy` and `SoapAuthorizationRule` classes to no longer use `pathPattern`, as it does not make sense for SOAP requests.
- Updated corresponding tests.
## 

**Screenshots:**

_SoapAuthorizationPolicyTest:_
<img width="1440" alt="screen shot 2016-04-22 at 11 43 13 am" src="https://cloud.githubusercontent.com/assets/3844502/14746946/fdc5d060-087f-11e6-9f2c-31573186de10.png">

_SoapAuthorizationPolicyConfigTest:_
<img width="1439" alt="screen shot 2016-04-22 at 11 42 56 am" src="https://cloud.githubusercontent.com/assets/3844502/14746936/f843004a-087f-11e6-8dd9-57c5e5be4664.png">
## 

**JIRA**: https://issues.jboss.org/browse/APIMAN-1103

Docs: https://github.com/apiman/apiman-guides/pull/18

cc @EricWittmann 
