### PR TITLE
Add apiman-common-logging-core to logging policy

### DIFF
--- a/log-policy/pom.xml
+++ b/log-policy/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>apiman-test-policies</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-common-logging-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Explicit rather than transitive.
