### PR TITLE
Adds unique header policy for request tracing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
     <module>simple-header-policy</module>
     <module>soap-authorization-policy</module>
     <module>transformation-policy</module>
+    <module>unique-header-policy</module>
     <module>url-whitelist-policy</module>
     <module>repository</module>
   </modules>

--- a/unique-header-policy/README.md
+++ b/unique-header-policy/README.md
@@ -1,0 +1,9 @@
+# unique-header-policy
+
+A policy that sets a unique value in a named header.
+
+This could be used for creating a correlation ID for tracking downstream API requests.
+
+## Author
+
+Pete Cornish <outofcoffee@gmail.com>

--- a/unique-header-policy/pom.xml
+++ b/unique-header-policy/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apiman.plugins</groupId>
+    <artifactId>apiman-plugins</artifactId>
+    <version>1.2.8-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>apiman-plugins-unique-header-policy</artifactId>
+  <packaging>war</packaging>
+  <name>apiman-plugins-unique-header-policy</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+
+    <!-- apiman dependencies (must be excluded from the WAR) -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-beans</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-gateway-engine-policies</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.apiman</groupId>
+      <artifactId>apiman-test-policies</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webResources>
+            <resource>
+              <directory>src/main/apiman</directory>
+              <targetPath>META-INF/apiman</targetPath>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/unique-header-policy/src/main/apiman/plugin.json
+++ b/unique-header-policy/src/main/apiman/plugin.json
@@ -1,0 +1,6 @@
+{
+  "frameworkVersion" : 1.0,
+  "name" : "Unique Header Policy Plugin",
+  "description" : "This plugin sets a unique value in a named header.",
+  "version" : "${project.version}"
+}

--- a/unique-header-policy/src/main/apiman/policyDefs/schemas/unique-header-policyDef.schema
+++ b/unique-header-policy/src/main/apiman/policyDefs/schemas/unique-header-policyDef.schema
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title" : "Unique Header Policy",
+  "description" : "Sets a unique value in a named header.",
+  "properties": {
+    "headerName": {
+      "type": "string",
+      "title": "HTTP Header Name"
+    }
+  }
+}

--- a/unique-header-policy/src/main/apiman/policyDefs/unique-header-policyDef.json
+++ b/unique-header-policy/src/main/apiman/policyDefs/unique-header-policyDef.json
@@ -1,0 +1,9 @@
+{
+  "id" : "unique-header-policy",
+  "name" : "Unique Header Policy",
+  "description" : "A policy that sets a unique value in a named header.",
+  "policyImpl" : "plugin:${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}/io.apiman.plugins.uniqueheader.UniqueHeaderPolicy",
+  "icon" : "fa-edit",
+  "formType" : "JsonSchema",
+  "form" : "schemas/unique-header-policyDef.schema"
+}

--- a/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/UniqueHeaderPolicy.java
+++ b/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/UniqueHeaderPolicy.java
@@ -1,0 +1,62 @@
+package io.apiman.plugins.uniqueheader;
+
+import io.apiman.gateway.engine.beans.ApiRequest;
+import io.apiman.gateway.engine.beans.exceptions.ConfigurationParseException;
+import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
+import io.apiman.gateway.engine.policy.IPolicyChain;
+import io.apiman.gateway.engine.policy.IPolicyContext;
+import io.apiman.plugins.uniqueheader.beans.UniqueHeaderBean;
+import io.apiman.plugins.uniqueheader.util.Messages;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.UUID;
+
+/**
+ * A policy that sets a unique value in a named header.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class UniqueHeaderPolicy extends AbstractMappedPolicy<UniqueHeaderBean> {
+    private static final Messages MESSAGES = new Messages("io.apiman.plugins.uniqueheader", "UniqueHeaderPolicy");
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#getConfigurationClass()
+     */
+    @Override
+    protected Class<UniqueHeaderBean> getConfigurationClass() {
+        return UniqueHeaderBean.class;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#parseConfiguration(String)
+     */
+    @Override
+    public UniqueHeaderBean parseConfiguration(String jsonConfiguration) throws ConfigurationParseException {
+        final UniqueHeaderBean config = super.parseConfiguration(jsonConfiguration);
+
+        // validate configuration
+        if (StringUtils.isBlank(config.getHeaderName())) {
+            throw new ConfigurationParseException(MESSAGES.format("Error.BlankHeaderName"));
+        }
+
+        return config;
+    }
+
+    /**
+     * @see io.apiman.gateway.engine.policies.AbstractMappedPolicy#doApply(io.apiman.gateway.engine.beans.ApiRequest, io.apiman.gateway.engine.policy.IPolicyContext, java.lang.Object, io.apiman.gateway.engine.policy.IPolicyChain)
+     */
+    @Override
+    protected void doApply(ApiRequest request, IPolicyContext context, UniqueHeaderBean config,
+                           IPolicyChain<ApiRequest> chain) {
+
+        request.getHeaders().put(config.getHeaderName(), generateUniqueString());
+        chain.doApply(request);
+    }
+
+    /**
+     * @return a unique String to set in the header
+     */
+    protected String generateUniqueString() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/beans/UniqueHeaderBean.java
+++ b/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/beans/UniqueHeaderBean.java
@@ -1,0 +1,53 @@
+package io.apiman.plugins.uniqueheader.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.io.Serializable;
+
+/**
+ * Configuration for the Unique Header Policy.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonPropertyOrder({"headerName"})
+public class UniqueHeaderBean implements Serializable {
+    /**
+     * The name of the HTTP Header to set.
+     */
+    @JsonProperty("headerName")
+    private String headerName;
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(headerName)
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof UniqueHeaderBean)) {
+            return false;
+        }
+        final UniqueHeaderBean rhs = ((UniqueHeaderBean) other);
+        return new EqualsBuilder()
+                .append(headerName, rhs.headerName)
+                .isEquals();
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
+}

--- a/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/util/Messages.java
+++ b/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/util/Messages.java
@@ -1,0 +1,45 @@
+package io.apiman.plugins.uniqueheader.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * Formats messages from a ResourceBundle.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class Messages {
+    private static final String DEFAULT_BUNDLE_NAME = "messages";
+
+    private final ResourceBundle resourceBundle;
+    private final String messagePrefix;
+
+    /**
+     * Creates a new {@link Messages} using the package name of the class as the path and the simple name of the
+     * class as the message prefix.
+     *
+     * @param packageName the package name of the bundle
+     * @param messagePrefix the message prefix (can be {@code null})
+     */
+    public Messages(String packageName, String messagePrefix) {
+        this.messagePrefix = (StringUtils.isNotBlank(messagePrefix) ? messagePrefix + "." : "");
+        this.resourceBundle = ResourceBundle.getBundle(packageName + "." + DEFAULT_BUNDLE_NAME);
+    }
+
+    /**
+     * Return the message <code>key</code> formatted with the given <code>params</code>.
+     *
+     * @param key    the message key in the ResourceBundle
+     * @param params the format arguments
+     * @return the formatted String
+     */
+    public String format(String key, Object... params) {
+        try {
+            return String.format(resourceBundle.getString(messagePrefix + key), params);
+        } catch (MissingResourceException e) {
+            return '!' + key + '!';
+        }
+    }
+}

--- a/unique-header-policy/src/main/resources/io/apiman/plugins/uniqueheader/messages.properties
+++ b/unique-header-policy/src/main/resources/io/apiman/plugins/uniqueheader/messages.properties
@@ -1,0 +1,1 @@
+UniqueHeaderPolicy.Error.BlankHeaderName=The HTTP Header Name configuration item is not set

--- a/unique-header-policy/src/test/java/io/apiman/plugins/uniqueheader/UniqueHeaderPolicyTest.java
+++ b/unique-header-policy/src/test/java/io/apiman/plugins/uniqueheader/UniqueHeaderPolicyTest.java
@@ -1,0 +1,71 @@
+package io.apiman.plugins.uniqueheader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apiman.gateway.engine.beans.exceptions.ConfigurationParseException;
+import io.apiman.test.policies.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Policy tests for {@link UniqueHeaderPolicy} plugin.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+@SuppressWarnings("nls")
+@TestingPolicy(UniqueHeaderPolicy.class)
+public class UniqueHeaderPolicyTest extends ApimanPolicyTest {
+    private static ObjectMapper jsonMapper;
+
+    /**
+     * Shared test initialisation.
+     */
+    @BeforeClass
+    public static void setUp() {
+        jsonMapper = new ObjectMapper();
+    }
+
+    /**
+     * Expects that a unique value is set with the HTTP Header name 'X-CorrelationID'.
+     *
+     * @throws Throwable
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    @Configuration(classpathConfigFile = "basic-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testUniqueValueSet() throws Throwable {
+        final PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/example");
+        final PolicyTestResponse response = send(request);
+
+        assertEquals(HttpURLConnection.HTTP_OK, response.code());
+        assertNotNull(response.body());
+
+        // the headers are mirrored back by the EchoBackEndApi in its response body
+        final Map<String, Object> responseAsMap = jsonMapper.readValue(response.body(), HashMap.class);
+        final Map<String, Object> headers = (Map<String, Object>) responseAsMap.get("headers");
+        assertNotNull(headers);
+        assertEquals(1, headers.size());
+        assertNotNull(headers.get("X-CorrelationID"));
+    }
+
+    /**
+     * Expects that a {@link ConfigurationParseException} is thrown if the header name configuration item is not set.
+     *
+     * @throws Throwable
+     */
+    @Test(expected = ConfigurationParseException.class)
+    @Configuration(classpathConfigFile = "empty-config.json")
+    @BackEndApi(EchoBackEndApi.class)
+    public void testValidateConfiguration() throws Throwable {
+        final PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/example");
+        send(request);
+
+        fail(ConfigurationParseException.class + " expected");
+    }
+}

--- a/unique-header-policy/src/test/resources/basic-config.json
+++ b/unique-header-policy/src/test/resources/basic-config.json
@@ -1,0 +1,3 @@
+{
+  "headerName": "X-CorrelationID"
+}

--- a/unique-header-policy/src/test/resources/empty-config.json
+++ b/unique-header-policy/src/test/resources/empty-config.json
@@ -1,0 +1,3 @@
+{
+  "headerName": ""
+}


### PR DESCRIPTION
A simple policy that sets a unique value in a named header.

This is very helpful for request tracing, stamping each request with a known ID that can be subsequently used when viewing logs etc.
