### PR TITLE
feat(jwt-policy) Can set headers as claim values or whole access token.

### DIFF
--- a/jwt-policy/src/main/apiman/policyDefs/schemas/jwt-policyDef.schema
+++ b/jwt-policy/src/main/apiman/policyDefs/schemas/jwt-policyDef.schema
@@ -10,10 +10,10 @@
             "default": true
         },
         "requireSigned": {
-        	"title": "Require Signed JWT (JWS).",
-        	"description": "Require JWTs be cryptographically signed and verified (JWS). It is strongly recommended this be enabled.",
-        	"type": "boolean",
-        	"default": true
+            "title": "Require Signed JWT (JWS).",
+            "description": "Require JWTs be cryptographically signed and verified (JWS). It is strongly recommended this be enabled.",
+            "type": "boolean",
+            "default": true
         },
         "requireTransportSecurity": {
             "title": "Require Transport Security",
@@ -34,11 +34,11 @@
             "format": "textarea"
         },
         "allowedClockSkew": {
-        	"title": "Maximum Clock Skew",
-        	"description": "Maximum allowed clock skew in seconds when validating exp (expiry) and nbf (not before) claims. Zero implies default behaviour.",
-        	"type": "integer",
-        	"default": 0,
-        	"minimum": 0
+            "title": "Maximum Clock Skew",
+            "description": "Maximum allowed clock skew in seconds when validating exp (expiry) and nbf (not before) claims. Zero implies default behaviour.",
+            "type": "integer",
+            "default": 0,
+            "minimum": 0
         },
         "requiredClaims": {
             "title": "Required Claims",
@@ -60,16 +60,42 @@
                     }
                 }
             },
-            "links": [
-                {
-                    "href": "https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims",
-                    "rel": "Specification: All standard claims and their descriptions. This includes name, preferred_username, email, etc."
-                },
-                {
-                    "href": "https://openid.net/specs/openid-connect-basic-1_0.html#IDToken",
-                    "rel": "Specification: Standard ID token fields"
+            "links": [{
+                "href": "https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims",
+                "rel": "Specification: All standard claims and their descriptions. This includes name, preferred_username, email, etc."
+            }, {
+                "href": "https://openid.net/specs/openid-connect-basic-1_0.html#IDToken",
+                "rel": "Specification: Standard ID token fields"
+            }]
+        },
+        "forwardAuthInfo": {
+            "title": "Forward Claim Information",
+            "description": "Fields from the JWT can be set as headers and forwarded to the API. All <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims\" target=\"_blank\">standard claims</a>, custom claims and <a href=\"https://openid.net/specs/openid-connect-basic-1_0.html#IDToken\" target=\"_blank\">ID token fields</a> are available (case sensitive). A special value of <strong><tt>access_token</tt></strong> will forward the entire encoded token. Nested claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>, <tt>address.formatted</tt>).",
+            "type": "array",
+            "format": "table",
+            "items": {
+                "type": "object",
+                "title": "Header",
+                "properties": {
+                    "header": {
+                        "title": "Header",
+                        "type": "string",
+                        "uniqueItems": true,
+                        "pattern": "^[^()<>@,;:\\\\<>\\/\\[\\]?={}\\s\\t]+$"
+                    },
+                    "field": {
+                        "title": "Field",
+                        "type": "string"
+                    }
                 }
-            ]
+            },
+            "links": [{
+                "href": "https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims",
+                "rel": "Specification: All standard claims and their descriptions. This includes name, preferred_username, email, etc."
+            }, {
+                "href": "https://openid.net/specs/openid-connect-basic-1_0.html#IDToken",
+                "rel": "Specification: Standard ID token fields"
+            }]
         }
     }
 }

--- a/jwt-policy/src/main/java/io/apiman/plugins/jwt/ConfigCheckingJwtHandler.java
+++ b/jwt-policy/src/main/java/io/apiman/plugins/jwt/ConfigCheckingJwtHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.plugins.jwt;
+
+import io.apiman.plugins.jwt.beans.JWTPolicyBean;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.JwtHandlerAdapter;
+
+import java.util.Collections;
+import java.util.Map;
+
+/*
+ * @author Marc Savy {@literal <msavy@redhat.com>}
+ */
+public class ConfigCheckingJwtHandler extends  JwtHandlerAdapter<Map<String, Object>> {
+
+    private JWTPolicyBean config;
+
+    ConfigCheckingJwtHandler(JWTPolicyBean config) {
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, Object> onPlaintextJwt(@SuppressWarnings("rawtypes") Jwt<Header, String> jwt) {
+        if (config.getRequireSigned()) {
+            super.onPlaintextJwt(jwt);
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, Object> onClaimsJwt(@SuppressWarnings("rawtypes") Jwt<Header, Claims> jwt) {
+        return config.getRequireSigned() ? super.onClaimsJwt(jwt) : jwt.getBody();
+    }
+
+    @Override
+    public Map<String, Object> onPlaintextJws(Jws<String> jws) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, Object> onClaimsJws(Jws<Claims> jws) {
+        return jws.getBody();
+    }
+}

--- a/jwt-policy/src/main/java/io/apiman/plugins/jwt/beans/ForwardAuthInfo.java
+++ b/jwt-policy/src/main/java/io/apiman/plugins/jwt/beans/ForwardAuthInfo.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({ "headers", "field" })
+@JsonPropertyOrder({ "header", "field" })
 public class ForwardAuthInfo {
 
     /**
@@ -43,8 +43,8 @@ public class ForwardAuthInfo {
      *
      *
      */
-    @JsonProperty("headers")
-    private String headers;
+    @JsonProperty("header")
+    private String header;
     /**
      * Field
      * <p>
@@ -61,11 +61,11 @@ public class ForwardAuthInfo {
      * <p>
      *
      *
-     * @return The headers
+     * @return The header
      */
-    @JsonProperty("headers")
-    public String getHeaders() {
-        return headers;
+    @JsonProperty("header")
+    public String getHeader() {
+        return header;
     }
 
     /**
@@ -73,16 +73,16 @@ public class ForwardAuthInfo {
      * <p>
      *
      *
-     * @param headers
-     *            The headers
+     * @param header
+     *            The header
      */
-    @JsonProperty("headers")
-    public void setHeaders(String headers) {
-        this.headers = headers;
+    @JsonProperty("header")
+    public void setHeader(String header) {
+        this.header = header;
     }
 
-    public ForwardAuthInfo withHeaders(String headers) {
-        this.headers = headers;
+    public ForwardAuthInfo withHeader(String header) {
+        this.header = header;
         return this;
     }
 

--- a/jwt-policy/src/main/java/io/apiman/plugins/jwt/beans/JWTPolicyBean.java
+++ b/jwt-policy/src/main/java/io/apiman/plugins/jwt/beans/JWTPolicyBean.java
@@ -34,33 +34,36 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * JWT Authentication Policy Configuration
- * <p>
  *
  * @author Marc Savy {@literal <msavy@redhat.com>}
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({ "requireJWT", "requireSigned", "requireTransportSecurity", "stripTokens", "signingKeyString", "requiredClaims", "forwardAuthInfo" })
+@JsonPropertyOrder({ "requireJWT", "requireSigned", "requireTransportSecurity", "stripTokens", "signingKeyString", "allowedClockSkew",
+        "requiredClaims", "forwardAuthInfo" })
 public class JWTPolicyBean {
-
-    @JsonProperty("requireSigned")
-    private Boolean requireSigned = true;
 
     /**
      * Require JWT
      * <p>
      * Terminate request if no JWT provided.
-     *
      */
     @JsonProperty("requireJWT")
     private Boolean requireJWT = true;
+    /**
+     * Require Signed JWT (JWS).
+     * <p>
+     * Require JWTs be cryptographically signed and verified (JWS). It is strongly recommended
+     * this be enabled.
+     */
+    @JsonProperty("requireSigned")
+    private Boolean requireSigned = true;
     /**
      * Require Transport Security
      * <p>
      * Any request used without transport security will be rejected. JWT requires transport
      * security (e.g. TLS, SSL) to provide protection against a variety of attacks. It is
      * strongly advised this option be switched on.
-     *
      */
     @JsonProperty("requireTransportSecurity")
     private Boolean requireTransportSecurity = true;
@@ -69,7 +72,6 @@ public class JWTPolicyBean {
      * <p>
      * Remove any Authorization header or token query parameter before forwarding traffic to
      * the API.
-     *
      */
     @JsonProperty("stripTokens")
     private Boolean stripTokens = false;
@@ -77,35 +79,45 @@ public class JWTPolicyBean {
      * Signing Key
      * <p>
      * To validate JWT. Must be Base-64 encoded.
-     *
      */
     @JsonProperty("signingKeyString")
     private String signingKeyString;
     private Key signingKey;
     /**
+     * Maximum Clock Skew
+     * <p>
+     * Maximum allowed clock skew in seconds when validating exp (expiry) and nbf (not before)
+     * claims. Zero implies default behaviour.
+     */
+    @JsonProperty("allowedClockSkew")
+    private Integer allowedClockSkew = 0;
+    /**
      * Required Claims
      * <p>
      * Require claims
      * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims" target=
-     * "_blank">standard claims, custom claims and ID token fields (case sensitive).
-     *
+     * "_blank">standard claims</a>, custom claims and
+     * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#IDToken" target=
+     * "_blank">ID token fields</a> (case sensitive).
      */
     @JsonProperty("requiredClaims")
     private List<RequiredClaim> requiredClaims = new ArrayList<>();
     /**
-     * Forward Keycloak Token Information
+     * Forward Claim Information
      * <p>
-     * Fields from the token can be set as headers and forwarded to the API. All
+     * Fields from the JWT can be set as headers and forwarded to the API. All
      * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims" target=
-     * "_blank">standard claims, custom claims and ID token fields are available (case
-     * sensitive). A special value of access_token will forward the entire encoded token.
-     *
+     * "_blank">standard claims</a>, custom claims and
+     * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#IDToken" target=
+     * "_blank">ID token fields</a> are available (case sensitive). A special value of
+     * <strong><tt>access_token</tt></strong> will forward the entire encoded token. Nested
+     * claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>,
+     * <tt>address.formatted</tt>).
      */
     @JsonProperty("forwardAuthInfo")
     private List<ForwardAuthInfo> forwardAuthInfo = new ArrayList<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<>();
-    private long allowedClockSkew;
 
     /**
      * Require JWT
@@ -134,6 +146,38 @@ public class JWTPolicyBean {
 
     public JWTPolicyBean withRequireJWT(Boolean requireJWT) {
         this.requireJWT = requireJWT;
+        return this;
+    }
+
+    /**
+     * Require Signed JWT (JWS).
+     * <p>
+     * Require JWTs be cryptographically signed and verified (JWS). It is strongly recommended
+     * this be enabled.
+     *
+     * @return The requireSigned
+     */
+    @JsonProperty("requireSigned")
+    public Boolean getRequireSigned() {
+        return requireSigned;
+    }
+
+    /**
+     * Require Signed JWT (JWS).
+     * <p>
+     * Require JWTs be cryptographically signed and verified (JWS). It is strongly recommended
+     * this be enabled.
+     *
+     * @param requireSigned
+     *            The requireSigned
+     */
+    @JsonProperty("requireSigned")
+    public void setRequireSigned(Boolean requireSigned) {
+        this.requireSigned = requireSigned;
+    }
+
+    public JWTPolicyBean withRequireSigned(Boolean requireSigned) {
+        this.requireSigned = requireSigned;
         return this;
     }
 
@@ -215,12 +259,8 @@ public class JWTPolicyBean {
         return signingKeyString;
     }
 
-    public Key getSigningKey() {
-        return signingKey;
-    }
-
     /**
-     * Signing Key String
+     * Signing Key
      * <p>
      * To validate JWT. Must be Base-64 encoded.
      *
@@ -242,11 +282,45 @@ public class JWTPolicyBean {
     }
 
     /**
+     * Maximum Clock Skew
+     * <p>
+     * Maximum allowed clock skew in seconds when validating exp (expiry) and nbf (not before)
+     * claims. Zero implies default behaviour.
+     *
+     * @return The allowedClockSkew
+     */
+    @JsonProperty("allowedClockSkew")
+    public Integer getAllowedClockSkew() {
+        return allowedClockSkew;
+    }
+
+    /**
+     * Maximum Clock Skew
+     * <p>
+     * Maximum allowed clock skew in seconds when validating exp (expiry) and nbf (not before)
+     * claims. Zero implies default behaviour.
+     *
+     * @param allowedClockSkew
+     *            The allowedClockSkew
+     */
+    @JsonProperty("allowedClockSkew")
+    public void setAllowedClockSkew(Integer allowedClockSkew) {
+        this.allowedClockSkew = allowedClockSkew;
+    }
+
+    public JWTPolicyBean withAllowedClockSkew(Integer allowedClockSkew) {
+        this.allowedClockSkew = allowedClockSkew;
+        return this;
+    }
+
+    /**
      * Required Claims
      * <p>
      * Require claims
      * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims" target=
-     * "_blank">standard claims, custom claims and ID token fields (case sensitive).
+     * "_blank">standard claims</a>, custom claims and
+     * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#IDToken" target=
+     * "_blank">ID token fields</a> (case sensitive).
      *
      * @return The requiredClaims
      */
@@ -260,7 +334,9 @@ public class JWTPolicyBean {
      * <p>
      * Require claims
      * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims" target=
-     * "_blank">standard claims, custom claims and ID token fields (case sensitive).
+     * "_blank">standard claims</a>, custom claims and
+     * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#IDToken" target=
+     * "_blank">ID token fields</a> (case sensitive).
      *
      * @param requiredClaims
      *            The requiredClaims
@@ -276,12 +352,16 @@ public class JWTPolicyBean {
     }
 
     /**
-     * Forward Keycloak Token Information
+     * Forward Claim Information
      * <p>
-     * Fields from the token can be set as headers and forwarded to the API. All
+     * Fields from the JWT can be set as headers and forwarded to the API. All
      * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims" target=
-     * "_blank">standard claims, custom claims and ID token fields are available (case
-     * sensitive). A special value of access_token will forward the entire encoded token.
+     * "_blank">standard claims</a>, custom claims and
+     * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#IDToken" target=
+     * "_blank">ID token fields</a> are available (case sensitive). A special value of
+     * <strong><tt>access_token</tt></strong> will forward the entire encoded token. Nested
+     * claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>,
+     * <tt>address.formatted</tt>).
      *
      * @return The forwardAuthInfo
      */
@@ -291,12 +371,16 @@ public class JWTPolicyBean {
     }
 
     /**
-     * Forward Keycloak Token Information
+     * Forward Claim Information
      * <p>
-     * Fields from the token can be set as headers and forwarded to the API. All
+     * Fields from the JWT can be set as headers and forwarded to the API. All
      * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims" target=
-     * "_blank">standard claims, custom claims and ID token fields are available (case
-     * sensitive). A special value of access_token will forward the entire encoded token.
+     * "_blank">standard claims</a>, custom claims and
+     * <a href="https://openid.net/specs/openid-connect-basic-1_0.html#IDToken" target=
+     * "_blank">ID token fields</a> are available (case sensitive). A special value of
+     * <strong><tt>access_token</tt></strong> will forward the entire encoded token. Nested
+     * claims can be accessed by using javascript dot syntax (e.g: <tt>address.country</tt>,
+     * <tt>address.formatted</tt>).
      *
      * @param forwardAuthInfo
      *            The forwardAuthInfo
@@ -326,24 +410,7 @@ public class JWTPolicyBean {
         return this;
     }
 
-    @JsonProperty("allowedClockSkew")
-    public long getAllowedClockSkew() {
-        return allowedClockSkew;
-    }
-
-    @JsonProperty("allowedClockSkew")
-    public JWTPolicyBean setAllowedClockSkew(long allowedClockSkew) {
-        this.allowedClockSkew = allowedClockSkew;
-        return this;
-    }
-
-    @JsonProperty("requireSigned")
-    public Boolean getRequireSigned() {
-        return requireSigned;
-    }
-
-    @JsonProperty("requireSigned")
-    public void setRequireSigned(Boolean requireSigned) {
-        this.requireSigned = requireSigned;
+    public Key getSigningKey() {
+        return signingKey;
     }
 }

--- a/jwt-policy/src/test/java/io/apiman/plugins/jwt/JWTPolicyTest.java
+++ b/jwt-policy/src/test/java/io/apiman/plugins/jwt/JWTPolicyTest.java
@@ -120,6 +120,52 @@ public class JWTPolicyTest extends ApimanPolicyTest {
             "  \"stripTokens\": true,\n" +
             "  \"signingKeyString\": \""+ PUBLIC_KEY_PEM +"\",\n" +
             "  \"allowedClockSkew\": 0,\n" +
+            "  \"requiredClaims\": [{ \"claimName\": \"sub\", \"claimValue\": \"aride\" }],\n" +
+            "  \"forwardAuthInfo\": [{ \"header\": \"X-Foo\", \"field\": \"sub\" }]\n" +
+            "}"
+    )
+    public void shouldForwardClaimsAsHeaders() throws Throwable {
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/amirante")
+                .header(AUTHORIZATION, "Bearer " + Jwts.builder().setSubject("aride").compact());
+
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+        Assert.assertEquals("aride", echo.getHeaders().get("X-Foo"));
+    }
+
+    @Test
+    @Configuration("{\n" +
+            "  \"requireJWT\": true,\n" +
+            "  \"requireSigned\": false,\n" +
+            "  \"requireTransportSecurity\": true,\n" +
+            "  \"stripTokens\": true,\n" +
+            "  \"signingKeyString\": \""+ PUBLIC_KEY_PEM +"\",\n" +
+            "  \"allowedClockSkew\": 0,\n" +
+            "  \"requiredClaims\": [{ \"claimName\": \"sub\", \"claimValue\": \"france frichot\" }],\n" +
+            "  \"forwardAuthInfo\": [{ \"header\": \"X-Foo\", \"field\": \"access_token\" }]\n" +
+            "}"
+    )
+    public void shouldForwardAccessTokenAsHeader() throws Throwable {
+        String token = unsignedToken();
+        PolicyTestRequest request = PolicyTestRequest.build(PolicyTestRequestType.GET, "/amirante")
+                .header(AUTHORIZATION, "Bearer " + token);
+
+        PolicyTestResponse response = send(request);
+        EchoResponse echo = response.entity(EchoResponse.class);
+        Assert.assertNotNull(echo);
+        Assert.assertEquals(token, echo.getHeaders().get("X-Foo"));
+    }
+
+
+    @Test
+    @Configuration("{\n" +
+            "  \"requireJWT\": true,\n" +
+            "  \"requireSigned\": false,\n" +
+            "  \"requireTransportSecurity\": true,\n" +
+            "  \"stripTokens\": true,\n" +
+            "  \"signingKeyString\": \""+ PUBLIC_KEY_PEM +"\",\n" +
+            "  \"allowedClockSkew\": 0,\n" +
             "  \"requiredClaims\": [{ \"claimName\": \"sub\", \"claimValue\": \"france frichot\" }]\n" +
             "}"
     )


### PR DESCRIPTION
Realised it'd be trivial to add this.