### PR TITLE
Option to log HTTP response status code.

### DIFF
--- a/log-policy/src/main/apiman/plugin.json
+++ b/log-policy/src/main/apiman/plugin.json
@@ -1,6 +1,6 @@
 {
   "frameworkVersion" : 1.0,
   "name" : "Log Policy Plugin",
-  "description" : "This plugin has policies for logging to std out.",
+  "description" : "This plugin has policies for logging HTTP headers.",
   "version" : "${project.version}"
 }

--- a/log-policy/src/main/apiman/policyDefs/schemas/log-policyDef.schema
+++ b/log-policy/src/main/apiman/policyDefs/schemas/log-policyDef.schema
@@ -8,6 +8,18 @@
       "title": "Direction",
       "description": "You may choose to log either the Request headers, Response headers, or both.",
       "enum": [ "request", "response", "both" ]
+    },
+    "logHeaders": {
+      "title": "Log Headers",
+      "description": "Whether to log the HTTP headers.",
+      "type": "boolean",
+      "default": true
+    },
+    "logStatusCode": {
+      "title": "Log Status Code",
+      "description": "Whether to log the HTTP response status code.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/log-policy/src/main/java/io/apiman/plugins/log_policy/beans/LogHeadersConfigBean.java
+++ b/log-policy/src/main/java/io/apiman/plugins/log_policy/beans/LogHeadersConfigBean.java
@@ -28,6 +28,19 @@ public class LogHeadersConfigBean {
     private LogHeadersDirectionType direction;
 
     /**
+     * Whether to log the request/response headers.
+     * Defaults to {@code true} for backwards compatibility.
+     */
+    @JsonProperty
+    private boolean logHeaders = true;
+
+    /**
+     * Whether to log the response status code.
+     */
+    @JsonProperty
+    private boolean logStatusCode;
+
+    /**
      * Constructor.
      */
     public LogHeadersConfigBean() {
@@ -47,4 +60,17 @@ public class LogHeadersConfigBean {
         this.direction = direction;
     }
 
+    /**
+     * @return whether to log the headers
+     */
+    public boolean isLogHeaders() {
+        return logHeaders;
+    }
+
+    /**
+     * @return whether to log the status code
+     */
+    public boolean isLogStatusCode() {
+        return logStatusCode;
+    }
 }

--- a/log-policy/src/test/java/io/apiman/plugins/log_policy/LogHeadersPolicyTest.java
+++ b/log-policy/src/test/java/io/apiman/plugins/log_policy/LogHeadersPolicyTest.java
@@ -23,7 +23,7 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
 	 * A simple happy flow test to verify the policy does not blow up in our face.
 	 */
 	@Test
-	@Configuration("{ \"direction\" : \"both\" }")
+	@Configuration("{ \"direction\" : \"both\", \"logStatusCode\" : true }")
 	public void testLogHeadersWithoutAnyRequestHeaders() throws PolicyFailureError, Throwable {
 	    PrintStream out = System.out;
 	    ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
@@ -35,11 +35,12 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
     		output = redactDates(output);
     		output = normalize(output);
     		String expected = "INFO: Logging 0 HTTP Request headers for io.apiman.test.policies.EchoBackEndApi\n" +
-    		        "INFO: Logging 4 HTTP Response headers for io.apiman.test.policies.EchoBackEndApi\n" +
-    		        "INFO: Key : Content-Length, Value : 167\n" +
-    		        "INFO: Key : Content-Type, Value : application/json\n" +
-    		        "INFO: Key : Date, Value : XXX\n" +
-    		        "INFO: Key : Server, Value : apiman.policy-test\n" +
+                    "INFO: Status code 200 for io.apiman.test.policies.EchoBackEndApi\n" +
+                    "INFO: Logging 4 HTTP Response headers for io.apiman.test.policies.EchoBackEndApi\n" +
+    		        "Key : Content-Length, Value : 167\n" +
+    		        "Key : Content-Type, Value : application/json\n" +
+    		        "Key : Date, Value : XXX\n" +
+    		        "Key : Server, Value : apiman.policy-test\n" +
     		        "";
     		Assert.assertEquals(expected, output);
         } finally {
@@ -51,7 +52,7 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
 	 * A simple happy flow test to verify the policy does not blow up in our face.
 	 */
 	@Test
-    @Configuration("{ \"direction\" : \"both\" }")
+    @Configuration("{ \"direction\" : \"both\", \"logStatusCode\" : true }")
 	public void testLogHeadersHappyFlow() throws PolicyFailureError, Throwable {
         PrintStream out = System.out;
         ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
@@ -66,12 +67,13 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
             output = redactDates(output);
             output = normalize(output);
             String expected = "INFO: Logging 1 HTTP Request headers for io.apiman.test.policies.EchoBackEndApi\n" +
-                    "INFO: Key : X-Test-Name, Value : testGet\n" +
+                    "Key : X-Test-Name, Value : testGet\n" +
+                    "INFO: Status code 200 for io.apiman.test.policies.EchoBackEndApi\n" +
                     "INFO: Logging 4 HTTP Response headers for io.apiman.test.policies.EchoBackEndApi\n" +
-                    "INFO: Key : Content-Length, Value : 199\n" +
-                    "INFO: Key : Content-Type, Value : application/json\n" +
-                    "INFO: Key : Date, Value : XXX\n" +
-                    "INFO: Key : Server, Value : apiman.policy-test\n" +
+                    "Key : Content-Length, Value : 199\n" +
+                    "Key : Content-Type, Value : application/json\n" +
+                    "Key : Date, Value : XXX\n" +
+                    "Key : Server, Value : apiman.policy-test\n" +
                     "";
             Assert.assertEquals(expected, output);
         } finally {
@@ -98,7 +100,7 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
             output = redactDates(output);
             output = normalize(output);
             String expected = "INFO: Logging 1 HTTP Request headers for io.apiman.test.policies.EchoBackEndApi\n" +
-                    "INFO: Key : X-Test-Name, Value : testGet\n" +
+                    "Key : X-Test-Name, Value : testGet\n" +
                     "";
             Assert.assertEquals(expected, output);
         } finally {
@@ -110,7 +112,7 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
      * A simple happy flow test to verify the policy does not blow up in our face.
      */
     @Test
-    @Configuration("{ \"direction\" : \"response\" }")
+    @Configuration("{ \"direction\" : \"response\", \"logStatusCode\" : true }")
     public void testLogHeadersHappyFlowResponseOnly() throws PolicyFailureError, Throwable {
         PrintStream out = System.out;
         ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
@@ -124,11 +126,12 @@ public class LogHeadersPolicyTest extends ApimanPolicyTest {
             String output = testOutput.toString("UTF-8");
             output = redactDates(output);
             output = normalize(output);
-            String expected = "INFO: Logging 4 HTTP Response headers for io.apiman.test.policies.EchoBackEndApi\n" +
-                    "INFO: Key : Content-Length, Value : 199\n" +
-                    "INFO: Key : Content-Type, Value : application/json\n" +
-                    "INFO: Key : Date, Value : XXX\n" +
-                    "INFO: Key : Server, Value : apiman.policy-test\n" +
+            String expected = "INFO: Status code 200 for io.apiman.test.policies.EchoBackEndApi\n" +
+                    "INFO: Logging 4 HTTP Response headers for io.apiman.test.policies.EchoBackEndApi\n" +
+                    "Key : Content-Length, Value : 199\n" +
+                    "Key : Content-Type, Value : application/json\n" +
+                    "Key : Date, Value : XXX\n" +
+                    "Key : Server, Value : apiman.policy-test\n" +
                     "";
             Assert.assertEquals(expected, output);
         } finally {


### PR DESCRIPTION
## Background

The existing log policy can log the HTTP request and response headers but not the response status code.

## The change

* Adds the ability to log the HTTP response status code to the log plugin.
* Combines the log statements for header logging into a single log event.
* Updates and adds to unit tests.

## Notes

* Options to enable status code and/or headers added to the policy configuration.
