### PR TITLE
Added source request HEADER for SimpleHeaderPolicy policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <version.source.plugin>2.4</version.source.plugin>
     <version.resources.plugin>2.7</version.resources.plugin>
     <version.war.plugin>2.5</version.war.plugin>
+    <version.assembly.plugin>3.1.1</version.assembly.plugin>
 
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -372,6 +373,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>${version.maven-gpg-plugin.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${version.assembly.plugin}</version>
         </plugin>
       <!--   <plugin> -->
       <!--     <groupId>org.apache.maven.plugins</groupId> -->

--- a/simple-header-policy/src/main/apiman/policyDefs/schemas/simple-header-PolicyDef.schema
+++ b/simple-header-policy/src/main/apiman/policyDefs/schemas/simple-header-PolicyDef.schema
@@ -10,7 +10,7 @@
       "items": {
         "type": "object",
         "title": "Header",
-        "description": "Set headers on request, response or both. A value type of 'String' sets the value literally; 'Env' treats the value as a key to the environment; 'System Properties' treats the value as a key to the JVM's System Properties.",
+        "description": "Set headers on request, response or both. A value type of 'String' sets the value literally; 'Env' treats the value as a key to the environment; 'System Properties' treats the value as a key to the JVM's System Properties; 'Header' reads the value from the header with name and copies that value.",
         "properties": {
           "headerName": {
             "title": "Header Name",
@@ -27,7 +27,8 @@
             "enum": [
               "String",
               "Env",
-              "System Properties"
+              "System Properties",
+              "Header"
             ]
           },
           "applyTo": {

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicy.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicy.java
@@ -42,7 +42,7 @@ public class SimpleHeaderPolicy extends AbstractMappedPolicy<SimpleHeaderPolicyD
     @Override
     protected void doApply(ApiRequest request, IPolicyContext context, SimpleHeaderPolicyDefBean config,
             IPolicyChain<ApiRequest> chain) {
-        setHeaders(request.getHeaders(), config, ApplyTo.REQUEST);
+        setHeadersRequest(request, config, ApplyTo.REQUEST);
         stripHeaders(request.getHeaders(), config, ApplyTo.REQUEST);
         chain.doApply(request);
     }
@@ -59,7 +59,18 @@ public class SimpleHeaderPolicy extends AbstractMappedPolicy<SimpleHeaderPolicyD
         for (AddHeaderBean header : config.getAddHeaders()) {
             if ((header.getApplyTo() == applyTo || header.getApplyTo() == ApplyTo.BOTH)) {
                 if (header.getOverwrite() || !headers.containsKey(header.getHeaderName())) {
-                    headers.put(header.getHeaderName(), header.getResolvedHeaderValue());
+                    headers.put(header.getHeaderName(), header.getResolvedHeaderValue(null));
+                }
+            }
+        }
+    }
+
+    private void setHeadersRequest(ApiRequest request, SimpleHeaderPolicyDefBean config, ApplyTo applyTo) {
+        HeaderMap headers = request.getHeaders();
+        for (AddHeaderBean header : config.getAddHeaders()) {
+            if ((header.getApplyTo() == applyTo || header.getApplyTo() == ApplyTo.BOTH)) {
+                if (header.getOverwrite() || !headers.containsKey(header.getHeaderName())) {
+                    headers.put(header.getHeaderName(), header.getResolvedHeaderValue(request));
                 }
             }
         }

--- a/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/AddHeaderBean.java
+++ b/simple-header-policy/src/main/java/io/apiman/plugins/simpleheaderpolicy/beans/AddHeaderBean.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.apiman.gateway.engine.beans.ApiRequest;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -266,7 +267,7 @@ public class AddHeaderBean {
 
     public static enum ValueType {
 
-        STRING("String"), ENV("Env"), SYS("System Properties");
+        STRING("String"), ENV("Env"), SYS("System Properties"), HEADER("Header");
         private final String value;
         private static Map<String, AddHeaderBean.ValueType> constants = new HashMap<>();
 
@@ -298,7 +299,7 @@ public class AddHeaderBean {
 
     }
 
-    public String getResolvedHeaderValue() {
+    public String getResolvedHeaderValue(ApiRequest request) {
         String rVal = null;
 
         switch (getValueType()) {
@@ -310,6 +311,13 @@ public class AddHeaderBean {
             break;
         case STRING:
             rVal = headerValue;
+            break;
+        case HEADER:
+            if(request == null) {
+                throw new IllegalArgumentException("Invalid access when reading header value.");
+            }
+            rVal = request.getHeaders().get(headerValue);
+            break;
         }
 
         return (rVal == null) ? "" : rVal;

--- a/simple-header-policy/src/test/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicyTest.java
+++ b/simple-header-policy/src/test/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicyTest.java
@@ -251,6 +251,23 @@ public class SimpleHeaderPolicyTest {
     }
 
     @Test
+    public void shouldGetValueFromRequestButNoHeader() {
+        AddHeaderBean header = spy(new AddHeaderBean());
+
+        header.setHeaderName("the-target-header");
+        header.setHeaderValue("the-header-to-read-from");
+        header.setOverwrite(true);
+        header.setApplyTo(ApplyTo.REQUEST);
+        header.setValueType(ValueType.HEADER);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertNull(request.getHeaders().get("the-target-header"));
+        assertEquals(0, request.getHeaders().size());
+    }
+
+    @Test
     public void shouldStripHeaderWithKey() {
         request.getHeaders().put("vanish", "begone");
 

--- a/simple-header-policy/src/test/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicyTest.java
+++ b/simple-header-policy/src/test/java/io/apiman/plugins/simpleheaderpolicy/SimpleHeaderPolicyTest.java
@@ -151,44 +151,103 @@ public class SimpleHeaderPolicyTest {
         assertEquals("Ridcully", request.getHeaders().get("X-Clacks-Overhead"));
         assertEquals(1, request.getHeaders().size());
     }
-    
+
 
     @Test
-    public void shouldGetValueFromEnvironment() {   
+    public void shouldGetValueFromEnvironment() {
         AddHeaderBean header = spy(new AddHeaderBean());
-        
+
         header.setHeaderName("the-meaning-of-life");
         header.setHeaderValue("KEY_TO_THE_ENVIRONMENT");
         header.setOverwrite(false);
         header.setApplyTo(ApplyTo.REQUEST);
         header.setValueType(ValueType.ENV);
         config.getAddHeaders().add(header);
-        
-        given(header.getResolvedHeaderValue()).willReturn("42");
+
+        request.getHeaders().put("the-meaning-of-life","42");
 
         policy.apply(request, mContext, config, mRequestChain);
 
         assertEquals("42", request.getHeaders().get("the-meaning-of-life"));
         assertEquals(1, request.getHeaders().size());
     }
-    
+
     @Test
     public void shouldGetValueFromSystemProperties() {
         System.setProperty("PROPERTIES_KEY", "42");
 
         AddHeaderBean header = spy(new AddHeaderBean());
-        
+
         header.setHeaderName("the-meaning-of-life");
         header.setHeaderValue("PROPERTIES_KEY");
         header.setOverwrite(false);
         header.setApplyTo(ApplyTo.REQUEST);
         header.setValueType(ValueType.SYS);
         config.getAddHeaders().add(header);
-        
+
         policy.apply(request, mContext, config, mRequestChain);
 
         assertEquals("42", request.getHeaders().get("the-meaning-of-life"));
         assertEquals(1, request.getHeaders().size());
+    }
+
+    @Test
+    public void shouldGetValueFromRequestOverwriteFalseHeaderExists() {
+        request.getHeaders().put("the-header-to-read-from","value-to-copy");
+        request.getHeaders().put("the-target-header","old-value-not-overwritten");
+
+        AddHeaderBean header = spy(new AddHeaderBean());
+
+        header.setHeaderName("the-target-header");
+        header.setHeaderValue("the-header-to-read-from");
+        header.setOverwrite(false);
+        header.setApplyTo(ApplyTo.REQUEST);
+        header.setValueType(ValueType.HEADER);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("old-value-not-overwritten", request.getHeaders().get("the-target-header"));
+        assertEquals(2, request.getHeaders().size());
+    }
+
+    @Test
+    public void shouldGetValueFromRequestOverwriteTrue() {
+        request.getHeaders().put("the-header-to-read-from","value-to-copy");
+        request.getHeaders().put("the-target-header","old-value-to-be-overwritten");
+
+        AddHeaderBean header = spy(new AddHeaderBean());
+
+        header.setHeaderName("the-target-header");
+        header.setHeaderValue("the-header-to-read-from");
+        header.setOverwrite(true);
+        header.setApplyTo(ApplyTo.REQUEST);
+        header.setValueType(ValueType.HEADER);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("value-to-copy", request.getHeaders().get("the-target-header"));
+        assertEquals(2, request.getHeaders().size());
+    }
+
+    @Test
+    public void shouldGetValueFromRequestOverwriteTrueHeaderExists() {
+        request.getHeaders().put("the-header-to-read-from","value-to-copy");
+
+        AddHeaderBean header = spy(new AddHeaderBean());
+
+        header.setHeaderName("the-target-header");
+        header.setHeaderValue("the-header-to-read-from");
+        header.setOverwrite(true);
+        header.setApplyTo(ApplyTo.REQUEST);
+        header.setValueType(ValueType.HEADER);
+        config.getAddHeaders().add(header);
+
+        policy.apply(request, mContext, config, mRequestChain);
+
+        assertEquals("value-to-copy", request.getHeaders().get("the-target-header"));
+        assertEquals(2, request.getHeaders().size());
     }
 
     @Test


### PR DESCRIPTION
This allows to retrieve a value from an existing header on the request and set it to a new header or to replace an existing header with that value. Current functionality was not changed.