### PR TITLE
JWT-Policy: Add support for JWK(S)

### DIFF
--- a/jwt-policy/pom.xml
+++ b/jwt-policy/pom.xml
@@ -30,6 +30,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>jwks-rsa</artifactId>
+    </dependency>
     <!-- apiman -->
     <dependency>
       <groupId>io.apiman</groupId>
@@ -60,6 +69,12 @@
     <dependency>
       <groupId>io.apiman</groupId>
       <artifactId>apiman-test-policies</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- mockserver -->
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jwt-policy/src/main/apiman/policyDefs/schemas/jwt-policyDef.schema
+++ b/jwt-policy/src/main/apiman/policyDefs/schemas/jwt-policyDef.schema
@@ -28,10 +28,15 @@
             "default": false
         },
         "signingKeyString": {
-            "title": "Signing Key",
-            "description": "To validate JWT. Must be Base-64 encoded.",
+            "title": "Signing Key or URL to a JWK(S)",
+            "description": "To validate JWT. Must be Base-64 encoded or you specify a URL to a JWK(S)",
             "type": "string",
             "format": "textarea"
+        },
+        "kid": {
+            "title": "Key ID (kid) of JWK(S)",
+            "description": "If you provided a JWK(S) URL above you can specify here the kid of the JWK(S)",
+            "type": "string"
         },
         "allowedClockSkew": {
             "title": "Maximum Clock Skew",

--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,15 @@
     <version.junit>4.11</version.junit>
 
     <version.commons-lang>2.6</version.commons-lang>
+    <version.commons-validator>1.6</version.commons-validator>
     <version.com.google.guava>21.0</version.com.google.guava>
     <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
     <version.org.keycloak>2.0.0.Final</version.org.keycloak>
     <version.org.bouncycastle>1.52</version.org.bouncycastle>
     <version.org.json>20140107</version.org.json>
-    <version.io.jsonwebtoken.jjwt>0.9.0</version.io.jsonwebtoken.jjwt>
+    <version.org.mock-server>5.6.0</version.org.mock-server>
+    <version.io.jsonwebtoken.jjwt>0.9.1</version.io.jsonwebtoken.jjwt>
+    <version.com.auth0.jwks-rsa>0.8.2</version.com.auth0.jwks-rsa>
   </properties>
 
   <repositories>
@@ -204,11 +207,22 @@
         <artifactId>mockito-all</artifactId>
         <version>${version.org.mockito}</version>
       </dependency>
+        <!-- mockserver -->
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>${version.org.mock-server}</version>
+        </dependency>
       <!-- others -->
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${version.commons-lang}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>${version.commons-validator}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -246,9 +260,14 @@
         <version>${version.org.json}</version>
       </dependency>
       <dependency>
-	<groupId>io.jsonwebtoken</groupId>
-	<artifactId>jjwt</artifactId>
-	<version>${version.io.jsonwebtoken.jjwt}</version>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt</artifactId>
+        <version>${version.io.jsonwebtoken.jjwt}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.auth0</groupId>
+        <artifactId>jwks-rsa</artifactId>
+        <version>${version.com.auth0.jwks-rsa}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
I had a few days off last week, but here is the promised PR that @bekihm mentioned last week.

JSON Web Keys and JSON Web Key Set are an easy way to retrieve a public key and validate a JWT with that key. If the public key change the JWK will be updated and there is no further requirement to update the config of the JWT Policy.
Read more about JWK here: https://auth0.com/docs/jwks

I added support of a JWKS URL in the policy configuration:
![image](https://user-images.githubusercontent.com/13332383/62450985-a93a4f80-b76d-11e9-86a0-a0eaae202cd6.png)

You can specify the signing key directly or add in the same field an URL. 
The check is in the policy implementation.
You can set a kid if you have more than one jwk in the key set (jwks).
The library caches the jwk for 10 hours.

I will add documentation for this as soon as I have time for it.

@EricWittmann That is the last open PR, after this you can go on with the release :)

Thanks @bekihm for reviewing this.