### PR TITLE
Adds property to allow headers to be passed down the stream

### DIFF
--- a/unique-header-policy/src/main/apiman/policyDefs/schemas/unique-header-policyDef.schema
+++ b/unique-header-policy/src/main/apiman/policyDefs/schemas/unique-header-policyDef.schema
@@ -7,6 +7,10 @@
     "headerName": {
       "type": "string",
       "title": "HTTP Header Name"
+    },
+    "overwriteHeaderValue": {
+      "type": "boolean",
+      "title": "Overwrite HTTP Header value"
     }
   }
 }

--- a/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/UniqueHeaderPolicy.java
+++ b/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/UniqueHeaderPolicy.java
@@ -2,6 +2,7 @@ package io.apiman.plugins.uniqueheader;
 
 import io.apiman.gateway.engine.beans.ApiRequest;
 import io.apiman.gateway.engine.beans.exceptions.ConfigurationParseException;
+import io.apiman.gateway.engine.beans.util.HeaderMap;
 import io.apiman.gateway.engine.policies.AbstractMappedPolicy;
 import io.apiman.gateway.engine.policy.IPolicyChain;
 import io.apiman.gateway.engine.policy.IPolicyContext;
@@ -49,8 +50,48 @@ public class UniqueHeaderPolicy extends AbstractMappedPolicy<UniqueHeaderBean> {
     protected void doApply(ApiRequest request, IPolicyContext context, UniqueHeaderBean config,
                            IPolicyChain<ApiRequest> chain) {
 
-        request.getHeaders().put(config.getHeaderName(), generateUniqueString());
+        request.setHeaders(handleHeader(request.getHeaders(), config));
         chain.doApply(request);
+    }
+
+    /**
+     * Handles the headers in regards to io.apiman.plugins.uniqueheader.beans.UniqueHeaderBean#isOverwriteHeader()
+     * by overwriting the io.apiman.plugins.uniqueheader.beans.UniqueHeaderBean#getHeaderName() if the overwriteHeader
+     * value is true
+     * @param headers provided in the request
+     * @param config the policy's configuration information
+     * @return the header map containing the new header
+     */
+    protected HeaderMap handleHeader(HeaderMap headers, UniqueHeaderBean config) {
+        if(!config.isOverwriteHeaderValue()){
+            if(!isHeaderPresent(headers, config)){
+                return putHeader(headers, config);
+            }
+            return headers;
+        }
+
+        return putHeader(headers, config);
+    }
+
+    /**
+     * Check if the expected header was provided
+     * @param headers provided in the request
+     * @param config the policy's configuration information
+     * @return true if the header is present
+     */
+    protected boolean isHeaderPresent(HeaderMap headers, UniqueHeaderBean config) {
+        return headers.containsKey(config.getHeaderName());
+    }
+
+    /**
+     * Adds a new header into the request.getHeaders()
+     * @param headerMap the request headers
+     * @param config the policy's configuration information
+     * @return the header map containing the new added header
+     */
+    protected HeaderMap putHeader(HeaderMap headerMap, UniqueHeaderBean config) {
+        headerMap.put(config.getHeaderName(), generateUniqueString());
+        return headerMap;
     }
 
     /**

--- a/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/beans/UniqueHeaderBean.java
+++ b/unique-header-policy/src/main/java/io/apiman/plugins/uniqueheader/beans/UniqueHeaderBean.java
@@ -14,13 +14,19 @@ import java.io.Serializable;
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
-@JsonPropertyOrder({"headerName"})
+@JsonPropertyOrder({"headerName", "overwriteHeaderValue"})
 public class UniqueHeaderBean implements Serializable {
     /**
      * The name of the HTTP Header to set.
      */
     @JsonProperty("headerName")
     private String headerName;
+
+    /**
+     * Overwrite the value provided in header
+     */
+    @JsonProperty("overwriteHeaderValue")
+    private boolean overwriteHeaderValue = false;
 
     @Override
     public int hashCode() {
@@ -49,5 +55,13 @@ public class UniqueHeaderBean implements Serializable {
 
     public void setHeaderName(String headerName) {
         this.headerName = headerName;
+    }
+
+    public boolean isOverwriteHeaderValue() {
+        return overwriteHeaderValue;
+    }
+
+    public void setOverwriteHeaderValue(boolean overwriteHeaderValue) {
+        this.overwriteHeaderValue = overwriteHeaderValue;
     }
 }

--- a/unique-header-policy/src/test/resources/not-overwrite-header-config.json
+++ b/unique-header-policy/src/test/resources/not-overwrite-header-config.json
@@ -1,0 +1,4 @@
+{
+  "headerName": "X-CorrelationID",
+  "overwriteHeaderValue": false
+}

--- a/unique-header-policy/src/test/resources/overwrite-header-config.json
+++ b/unique-header-policy/src/test/resources/overwrite-header-config.json
@@ -1,0 +1,4 @@
+{
+  "headerName": "X-CorrelationID",
+  "overwriteHeaderValue": true
+}


### PR DESCRIPTION
The unique-header-policy discards the header value set in `headerName` property if is sent by the source system and replace it with a new random value. 

This change is meant to allow the user to specify wether it needs to keep the received value for the header and pass it down the stream or discard the value and replace it with a random one using `overwriteHeader` boolean
