### PR TITLE
JWK(s) Support for Keycloak OAuth Policy

### DIFF
--- a/keycloak-oauth-policy/pom.xml
+++ b/keycloak-oauth-policy/pom.xml
@@ -28,6 +28,18 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-adapter-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-common</artifactId>
     </dependency>
@@ -66,6 +78,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- mockserver -->
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
+++ b/keycloak-oauth-policy/src/main/apiman/policyDefs/schemas/keycloak-oauth-policyDef.schema
@@ -11,30 +11,30 @@
     },
     "requireTransportSecurity": {
       "title": "Require Transport Security",
-      "description": "Any request used without transport security will be rejected. OAuth2 requires transport security (e.g. TLS, SSL) to provide protection against replay attacks. It is strongly advised for this option to be switched on.",
+      "description": "Any request without transport security will be rejected. OAuth2 requires transport security (e.g. TLS, SSL) to provide protection against replay attacks. It is strongly recommended to enable this option.",
       "type": "boolean",
       "default": true
     },
     "blacklistUnsafeTokens": {
       "title": "Blacklist Unsafe Tokens",
-      "description": "Any tokens used without transport security will be blackedlisted in all gateways to mitigate associated security risks. Uses distributed data store to share blacklist.",
+      "description": "Any tokens used without transport security will be blacklisted in all gateways to mitigate associated security risks. Uses distributed data store to share blacklist.",
       "type": "boolean",
       "default": false
     },
     "stripTokens": {
       "title": "Strip Tokens",
-      "description": "Remove any Authorization header or token query parameter before forwarding traffic to the API.",
+      "description": "Remove any authorization header or token query parameter before forwarding traffic to the API.",
       "type": "boolean",
       "default": false
     },
     "realm": {
       "title": "Realm",
-      "description": "Realm name. If you are using Keycloak 1.2.0x or later this must be a full iss domain path (e.g. https://mykeycloak.local/auth/realms/apimanrealm); pre-1.2.0x simply use the realm name (e.g. apimanrealm).",
+      "description": "Realm name. Must be a full ISS domain path (e.g. https://mykeycloak.local/auth/realms/apimanrealm) is required.",
       "type": "string"
     },
     "realmCertificateString": {
       "title": "Keycloak Realm Certificate",
-      "description": "To validate OAuth2 requests. Must be a PEM-encoded X.509 certificate.",
+      "description": "To validate OAuth2 requests. Must be a PEM-encoded X.509 certificate. If you leave this empty the policy will try to get the public-keys directly from your Keycloak.",
       "type": "string",
       "format": "textarea"
     },
@@ -68,13 +68,13 @@
     },
     "delegateKerberosTicket": {
       "title": "Delegate Kerberos Ticket",
-      "description": "Delegate any Kerberos Ticket embedded in the Keycloak token to the API (via the Authorization header).",
+      "description": "Delegate any Kerberos ticket embedded in the Keycloak token to the API (via the authorization header).",
       "type": "boolean",
       "default": false,
       "links": [
         {
           "href": "https://keycloak.github.io/docs/userguide/keycloak-server/html/kerberos.html#d4e3080",
-          "rel": "Keycloak Kerberos credential delegation guide"
+          "rel": "Goto Keycloak Kerberos Credential Delegation Guide"
         }
       ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,10 @@
     <version.commons-validator>1.6</version.commons-validator>
     <version.com.google.guava>21.0</version.com.google.guava>
     <version.com.fasterxml.jackson>2.10.0</version.com.fasterxml.jackson>
-    <version.org.keycloak>2.0.0.Final</version.org.keycloak>
-    <version.org.bouncycastle>1.52</version.org.bouncycastle>
+    <version.org.apache.httpcomponents>4.5.13</version.org.apache.httpcomponents>
+    <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
+    <version.org.keycloak>11.0.3</version.org.keycloak>
+    <version.org.bouncycastle>1.60</version.org.bouncycastle>
     <version.org.json>20140107</version.org.json>
     <version.org.mock-server>5.6.0</version.org.mock-server>
     <version.io.jsonwebtoken.jjwt>0.9.1</version.io.jsonwebtoken.jjwt>
@@ -205,6 +207,16 @@
         </dependency>
       <!-- others -->
       <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${version.org.apache.httpcomponents}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>${version.org.jboss.logging}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${version.commons-lang}</version>
@@ -233,6 +245,11 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${version.com.google.guava}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-adapter-core</artifactId>
+        <version>${version.org.keycloak}</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
@@ -435,6 +452,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Keycloak provides an endpoint for certificates and returns a JWK(s).
The policy should use this endpoint in favor of a hardcoded certificate in the policy configuration.

If you leave the realm-certificate empty then the policy will try to fetch the public-key from keycloak.
![image](https://user-images.githubusercontent.com/13332383/100984146-9941a400-354a-11eb-973d-3755ddc8d849.png)

The changes are backward compatible and will not break any existing configuration.
Updated documentation will follow soon.

Thanks, @p-muessig for the review :)