### PR TITLE
Support Java 8-15

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -21,14 +21,17 @@ jobs:
   build-verify:
     name: Verify Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11, 15 ]
     if: github.repository_owner == 'Apiman'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - name: Build Project
         run: mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.skip.test=true -DskipTests=true
       - name: Run Tests

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build Project
         run: mvn clean install -Dinvoker.skip -Dmaven.javadoc.skip=true -Dmvn.skip.test=true -DskipTests=true
       - name: Run Tests

--- a/auth-3scale/pom.xml
+++ b/auth-3scale/pom.xml
@@ -29,6 +29,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
 
 
     <!-- apiman dependencies (must be excluded from the WAR) -->

--- a/cors-policy/pom.xml
+++ b/cors-policy/pom.xml
@@ -42,6 +42,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/http-security-policy/pom.xml
+++ b/http-security-policy/pom.xml
@@ -14,6 +14,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/jwt-policy/pom.xml
+++ b/jwt-policy/pom.xml
@@ -39,6 +39,10 @@
       <groupId>com.auth0</groupId>
       <artifactId>jwks-rsa</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
     <!-- apiman -->
     <dependency>
       <groupId>io.apiman</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@
     <version.org.mock-server>5.6.0</version.org.mock-server>
     <version.io.jsonwebtoken.jjwt>0.9.1</version.io.jsonwebtoken.jjwt>
     <version.com.auth0.jwks-rsa>0.8.2</version.com.auth0.jwks-rsa>
+    <version.jakarta.annotation>1.3.5</version.jakarta.annotation>
+    <version.javax.xml.bind>2.3.1</version.javax.xml.bind>
   </properties>
 
   <repositories>
@@ -281,6 +283,16 @@
         <artifactId>jwks-rsa</artifactId>
         <version>${version.com.auth0.jwks-rsa}</version>
       </dependency>
+      <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>${version.jakarta.annotation}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${version.javax.xml.bind}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -307,9 +319,9 @@
 
   <profiles>
     <profile>
-      <id>java8</id>
+      <id>java11</id>
       <activation>
-        <jdk>[1.8,)</jdk>
+        <jdk>[11,)</jdk>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -63,22 +63,22 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
 
-    <version.apiman>2.0.0.Final</version.apiman>
-    <version.javadoc.plugin>2.10.1</version.javadoc.plugin>
+    <version.apiman>2.0.1-SNAPSHOT</version.apiman>
+    <version.javadoc.plugin>3.2.0</version.javadoc.plugin>
     <version.compiler.plugin>3.2</version.compiler.plugin>
     <version.enforcer.plugin>1.4</version.enforcer.plugin>
     <version.maven-gpg-plugin.plugin>1.5</version.maven-gpg-plugin.plugin>
     <version.nexus-staging-maven-plugin.plugin>1.6.3</version.nexus-staging-maven-plugin.plugin>
     <version.source.plugin>2.4</version.source.plugin>
-    <version.resources.plugin>2.7</version.resources.plugin>
+    <version.resources.plugin>3.1.0</version.resources.plugin>
     <version.war.plugin>2.5</version.war.plugin>
-    <version.assembly.plugin>3.1.1</version.assembly.plugin>
+    <version.assembly.plugin>3.2.0</version.assembly.plugin>
 
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
 
     <version.org.mockito>1.9.5</version.org.mockito>
-    <version.junit>4.11</version.junit>
+    <version.junit>4.13.1</version.junit>
 
     <version.commons-lang>2.6</version.commons-lang>
     <version.commons-validator>1.6</version.commons-validator>
@@ -86,7 +86,7 @@
     <version.com.fasterxml.jackson>2.10.0</version.com.fasterxml.jackson>
     <version.org.apache.httpcomponents>4.5.13</version.org.apache.httpcomponents>
     <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
-    <version.org.keycloak>11.0.3</version.org.keycloak>
+    <version.org.keycloak>12.0.1</version.org.keycloak>
     <version.org.bouncycastle>1.60</version.org.bouncycastle>
     <version.org.json>20140107</version.org.json>
     <version.org.mock-server>5.6.0</version.org.mock-server>
@@ -319,9 +319,9 @@
 
   <profiles>
     <profile>
-      <id>java11</id>
+      <id>java8</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <jdk>[1.8,)</jdk>
       </activation>
       <build>
         <plugins>
@@ -329,7 +329,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
+              <!-- Skip Javadoc errors that are fatal on Java 8+ -->
+              <doclint>none</doclint>
+              <!-- https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+              <source>8</source>
             </configuration>
           </plugin>
         </plugins>

--- a/simple-header-policy/pom.xml
+++ b/simple-header-policy/pom.xml
@@ -25,6 +25,10 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
 
     <!-- apiman dependencies (must be excluded from the WAR) -->
     <dependency>


### PR DESCRIPTION
I've built on top of @bekihm's suggested changes and aligned everything with the proposed changes on apiman/apiman -- it now seems to work well with all current versions of Java.

I've reverted the bit where @bekihm changed the doclint to only apply from Java 11 onwards. It's needed from Java 11 onwards, and the existing syntax captures that.

I've extended the GH Actions build to test against 8, 11, and 15.