### PR TITLE
fix(keycloak-oauth-policy): detect simple types and avoid access errors

### DIFF
--- a/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/ClaimLookup.java
+++ b/keycloak-oauth-policy/src/main/java/io/apiman/plugins/keycloak_oauth_policy/ClaimLookup.java
@@ -16,6 +16,10 @@
 
 package io.apiman.plugins.keycloak_oauth_policy;
 
+
+import io.apiman.common.logging.ApimanLoggerFactory;
+import io.apiman.common.logging.IApimanLogger;
+
 import java.lang.reflect.Field;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -32,32 +36,56 @@ import org.keycloak.representations.JsonWebToken;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
-* @author Marc Savy {@literal <msavy@redhat.com>}
-*/
+ * Use introspection to look up values in an AccessToken.
+ *
+ * @author Marc Savy {@literal <msavy@redhat.com>}
+ */
 @SuppressWarnings("nls")
 public class ClaimLookup {
     private static final Map<String, List<Field>> STANDARD_CLAIMS_FIELD_MAP = new LinkedHashMap<>();
+    private static final IApimanLogger LOGGER = ApimanLoggerFactory.getLogger(ClaimLookup.class);
 
     static {
         Class<?> clazz = AccessToken.class;
         do {
-            getProperties(clazz, "", new ArrayDeque<Field>());
+            getProperties(clazz, "", new ArrayDeque<>());
         } while ((clazz = clazz.getSuperclass()) != null);
         // Legacy mappings, to ensure old configs keep working
         STANDARD_CLAIMS_FIELD_MAP.put("username", STANDARD_CLAIMS_FIELD_MAP.get(IDToken.PREFERRED_USERNAME));
         STANDARD_CLAIMS_FIELD_MAP.put("subject", STANDARD_CLAIMS_FIELD_MAP.get("sub"));
     }
 
+    /**
+     * Get a claim by name.
+     *
+     * @param token token to retrieve claim from
+     * @param claim the claim (field key)
+     * @return string representation of claim
+     */
+    public static <T extends AccessToken> String getClaim(T token, String claim) {
+        if (claim == null || token == null) {
+            return null;
+        }
+        // Get the standard claim field, if available
+        if (STANDARD_CLAIMS_FIELD_MAP.containsKey(claim)) {
+            return callClaimChain(token, STANDARD_CLAIMS_FIELD_MAP.get(claim));
+        } else { // Otherwise, look up 'other claims'
+            Object otherClaim = getOtherClaimValue(token, claim);
+            return otherClaim == null ? null : otherClaim.toString();
+        }
+    }
+
     private static void getProperties(Class<?> klazz, String path, Deque<Field> fieldChain) {
-        for (Field f: klazz.getDeclaredFields()) {
+        for (Field f : klazz.getDeclaredFields()) {
             f.setAccessible(true);
             JsonProperty jsonProperty = f.getAnnotation(JsonProperty.class);
             if (jsonProperty != null) {
                 fieldChain.push(f);
                 // If the inspected type has nested @JsonProperty annotations, we need to inspect it
-                if (hasJsonPropertyAnnotation(f)) {
+                if (!terminalType(f) && hasJsonPropertyAnnotation(f)) {
                     getProperties(f.getType(), f.getName() + ".", fieldChain); // Add "." when traversing into new object.
-                } else { // Otherwise, just assume it's simple as the best we can do is #toString
+                } else {
+                    // Otherwise, just assume it's simple as the best we can do is #toString
                     List<Field> fieldList = new ArrayList<>(fieldChain);
                     Collections.reverse(fieldList);
                     STANDARD_CLAIMS_FIELD_MAP.put(path + jsonProperty.value(), fieldList);
@@ -67,45 +95,33 @@ public class ClaimLookup {
         }
     }
 
+    private static boolean terminalType(Field f) {
+        return f.getType().isPrimitive()
+             || f.getType().isArray()
+             || f.getType().getCanonicalName().startsWith("java.lang");
+    }
+
     private static boolean hasJsonPropertyAnnotation(Field f) {
         for (Field g : f.getType().getDeclaredFields()) {
             g.setAccessible(true);
-            if (g.getAnnotation(JsonProperty.class) != null)
+            if (g.getAnnotation(JsonProperty.class) != null) {
                 return true;
+            }
         }
         return false;
-    }
-
-    /**
-     *
-     * @param token token to retrieve claim from
-     * @param claim the claim (field key)
-     * @return string representaion of claim
-     */
-    public static String getClaim(IDToken token, String claim) {
-      if (claim == null || token == null)
-          return null;
-      // Get the standard claim field, if available
-      if (STANDARD_CLAIMS_FIELD_MAP.containsKey(claim)) {
-          return callClaimChain(token, STANDARD_CLAIMS_FIELD_MAP.get(claim));
-      } else { // Otherwise look up 'other claims'
-          Object otherClaim = getOtherClaimValue(token, claim);
-          return otherClaim == null ? null : otherClaim.toString();
-      }
     }
 
     private static String callClaimChain(Object rootObject, List<Field> list) {
         try {
             Object candidate = rootObject;
             for (Field f : list) {
-                if ((candidate = f.get(candidate)) == null)
+                if ((candidate = f.get(candidate)) == null) {
                     break;
+                }
             }
             return (candidate == null) ? null : candidate.toString();
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            // TODO Use logger. These exceptions shouldn't occur, but if it somehow does happen we need to know.
-            System.err.println("Unexpected error looking up token field: " + e); //$NON-NLS-1$
-            e.printStackTrace();
+            LOGGER.error(e, "Unexpected error looking up token field: ", e.getMessage());
         }
         return null;
     }
@@ -119,8 +135,9 @@ public class ClaimLookup {
                 return jsonObject.get(split[i]);
             } else {
                 Object val = jsonObject.get(split[i]);
-                if (!(val instanceof Map))
+                if (!(val instanceof Map)) {
                     return null;
+                }
                 jsonObject = (Map<String, Object>) val;
             }
         }

--- a/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyLegacyTest.java
+++ b/keycloak-oauth-policy/src/test/java/io/apiman/plugins/keycloak_oauth_policy/KeycloakOauthPolicyLegacyTest.java
@@ -128,15 +128,6 @@ public class KeycloakOauthPolicyLegacyTest {
             willReturn(new InMemorySharedStateComponent());
     }
 
-    private String generateAndSerializeToken() throws CertificateEncodingException, IOException {
-        token.notBefore(Time.currentTime() - 100);
-
-        config.setRealm("apiman-realm");
-        config.setRealmCertificateString(certificateAsPem(idpCertificates[0]));
-
-        return new JWSBuilder().jsonContent(token).rsa256(idpPair.getPrivate());
-    }
-
     @Test
     public void subjectToSub() throws CertificateEncodingException, IOException {
         ForwardAuthInfo authInfo = new ForwardAuthInfo();
@@ -184,5 +175,14 @@ public class KeycloakOauthPolicyLegacyTest {
             writer.close();
         }
         return sw.toString();
+    }
+
+    private String generateAndSerializeToken() throws CertificateEncodingException, IOException {
+        token.notBefore(Time.currentTime() - 100);
+
+        config.setRealm("apiman-realm");
+        config.setRealmCertificateString(certificateAsPem(idpCertificates[0]));
+
+        return new JWSBuilder().jsonContent(token).rsa256(idpPair.getPrivate());
     }
 }


### PR DESCRIPTION
When pre-indexing the claims fields via reflection, ensure we do not try to traverse into
basic/internal Java objects such as String, as this causes access errors and is not useful anyway.